### PR TITLE
fix: use graph.instagram.com for Instagram API base URL

### DIFF
--- a/src/services/meta-client.ts
+++ b/src/services/meta-client.ts
@@ -2,6 +2,7 @@ import { MetaConfig } from "../config.js";
 import { RateLimit } from "../types.js";
 
 const IG_BASE = "https://graph.instagram.com/v25.0";
+const FB_BASE = "https://graph.facebook.com/v25.0";
 const THREADS_BASE = "https://graph.threads.net/v1.0";
 
 interface ClientResponse {
@@ -104,7 +105,7 @@ export class MetaClient {
       throw new Error("META_APP_ID and META_APP_SECRET are required.");
     }
     const appToken = `${this.config.appId}|${this.config.appSecret}`;
-    return this.request(IG_BASE, appToken, method, path, params);
+    return this.request(FB_BASE, appToken, method, path, params);
   }
 
   /** Exchange short-lived token for long-lived token */
@@ -112,7 +113,7 @@ export class MetaClient {
     if (!this.config.appId || !this.config.appSecret) {
       throw new Error("META_APP_ID and META_APP_SECRET are required for token exchange.");
     }
-    return this.request(IG_BASE, shortToken, "GET", "/oauth/access_token", {
+    return this.request(FB_BASE, shortToken, "GET", "/oauth/access_token", {
       grant_type: "fb_exchange_token",
       client_id: this.config.appId,
       client_secret: this.config.appSecret,
@@ -122,7 +123,7 @@ export class MetaClient {
 
   /** Refresh a long-lived token */
   async refreshToken(longToken: string): Promise<ClientResponse> {
-    return this.request(IG_BASE, longToken, "GET", "/oauth/access_token", {
+    return this.request(FB_BASE, longToken, "GET", "/oauth/access_token", {
       grant_type: "fb_exchange_token",
     });
   }
@@ -133,7 +134,7 @@ export class MetaClient {
       throw new Error("META_APP_ID and META_APP_SECRET are required for token debug.");
     }
     const appToken = `${this.config.appId}|${this.config.appSecret}`;
-    return this.request(IG_BASE, appToken, "GET", "/debug_token", {
+    return this.request(FB_BASE, appToken, "GET", "/debug_token", {
       input_token: inputToken,
     });
   }


### PR DESCRIPTION
## Summary

The Instagram API with Instagram Login (the current recommended setup in Meta Developer Dashboard) uses `graph.instagram.com`, not `graph.facebook.com`. Tokens generated via the Instagram API setup (`IGAA...` prefix) are only valid on `graph.instagram.com` and are rejected by `graph.facebook.com` with "Cannot parse access token".

## Problem

`meta-client.ts` used a single `IG_BASE` constant (`graph.facebook.com`) for **both** Instagram API calls and Meta platform calls (token exchange, debug, webhooks). This fails for `IGAA...` tokens.

Simply changing `IG_BASE` to `graph.instagram.com` fixes Instagram but **breaks Meta platform tools** — endpoints like `/oauth/access_token` and `/debug_token` are Facebook Graph API endpoints that only exist on `graph.facebook.com`.

## Fix

Split into two base URL constants:

| Constant | URL | Used by |
|----------|-----|---------|
| `IG_BASE` | `graph.instagram.com/v25.0` | `ig()` — all 33 Instagram tools |
| `FB_BASE` | `graph.facebook.com/v25.0` | `meta()`, `exchangeToken()`, `refreshToken()`, `debugToken()` — 6 Meta tools |

`graph.instagram.com` accepts both `IGAA...` (Instagram Login) and `EAA...` (Facebook Login) tokens, making it the correct universal endpoint for Instagram operations.

## Files changed

- `src/services/meta-client.ts` — add `FB_BASE`, route Meta platform methods through it

## Test plan

- [ ] Instagram API calls work with `IGAA...` tokens (Instagram Login flow)
- [ ] Instagram API calls still work with `EAA...` tokens (Facebook Login flow)
- [ ] `meta_exchange_token` works (uses `graph.facebook.com`)
- [ ] `meta_debug_token` works (uses `graph.facebook.com`)
- [ ] `meta_refresh_token` works (uses `graph.facebook.com`)