### PR TITLE
fix: add .env to .gitignore to prevent secret exposure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Instagram API credentials
+INSTAGRAM_ACCESS_TOKEN=your_instagram_access_token
+INSTAGRAM_USER_ID=your_instagram_user_id
+
+# Threads API credentials
+THREADS_ACCESS_TOKEN=your_threads_access_token
+THREADS_USER_ID=your_threads_user_id
+
+# Meta App credentials (for token exchange and webhook tools)
+META_APP_ID=your_meta_app_id
+META_APP_SECRET=your_meta_app_secret

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ dist/
 *.tsbuildinfo
 .DS_Store
 .idea/
+
+# Environment files with secrets
+.env
+.env.*
+.env.local
+.env.*.local
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **`threads_reply` video polling silently proceeds on timeout** — replaced the inline wait loop (which lacked a timeout error) with the shared `waitForThreadsContainer()` helper that correctly throws on timeout, preventing publication of unfinished video containers ([#21](https://github.com/exileum/meta-mcp/issues/21))
 - **RateLimit fields always `undefined`** — `parseRateLimit()` now maps Meta's snake_case `x-app-usage` header fields (`call_count`, `total_cpu_time`, `total_time`) to the camelCase `RateLimit` interface, fixing silently broken rate limit data in all tool responses ([#20](https://github.com/exileum/meta-mcp/issues/20))
+- **`.env` not in `.gitignore`** — added `.env*` patterns to prevent accidental secret exposure, and created `.env.example` for developer onboarding ([#22](https://github.com/exileum/meta-mcp/issues/22))
 
 ## [3.2.0] — 2026-04-04
 


### PR DESCRIPTION
## Summary

- Added `.env*` patterns to `.gitignore` (with `!.env.example` exception)
- Created `.env.example` with placeholder values for developer onboarding
- Updated CHANGELOG.md

## What was broken

`.gitignore` only had `node_modules/`, `dist/`, `*.tsbuildinfo`, `.DS_Store`, and `.idea/` — no `.env` patterns. Developers using `.env` files for local development could accidentally commit secrets (Instagram/Threads tokens, Meta App Secret) to the public repo via `git add .`.

## What this PR does

1. **`.gitignore`** — adds `.env`, `.env.*`, `.env.local`, `.env.*.local` patterns with `!.env.example` exception
2. **`.env.example`** — new file with all 6 environment variables as placeholders, matching the README docs
3. **`CHANGELOG.md`** — documents the fix under `[Unreleased]`

## Breaking changes

None.

## Files changed

- `.gitignore` — added env patterns
- `.env.example` — new file
- `CHANGELOG.md` — added entry

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 18 tests pass
- [x] Created a `.env` file → confirmed `git status` ignores it
- [x] `.env.example` is tracked and not ignored

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed: `.env` was missing from `.gitignore`, preventing accidental exposure of sensitive credentials.

* **Chores**
  * Added `.env.example` configuration template for application setup reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->