### PR TITLE
chore: publish to GitHub Packages npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
     outputs:
       released: ${{ steps.version.outputs.released }}
       tag: ${{ steps.version.outputs.tag }}
@@ -52,3 +53,16 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.released == 'true'
         run: npm publish --provenance --access public
+
+      - name: Setup Node for GitHub Packages
+        if: steps.version.outputs.released == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish to GitHub Packages
+        if: steps.version.outputs.released == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Publish to GitHub Packages** — the release workflow now publishes to the GitHub Packages npm registry (`npm.pkg.github.com`) in addition to npmjs.com, providing an alternative installation source and tighter GitHub ecosystem integration ([#18](https://github.com/exileum/meta-mcp/issues/18))
+
 ## [3.3.0] — 2026-04-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add GitHub Packages as a secondary npm registry for `@exileum/meta-mcp`
- Package will be published to both npmjs.com and `npm.pkg.github.com` on every release

Fixes #18

## What was missing

The package was only published to the public npm registry (npmjs.com). No GitHub Packages integration existed.

## What this PR does

Adds two steps to the release workflow (`.github/workflows/release.yml`):
1. **Setup Node for GitHub Packages** — re-runs `setup-node` with `registry-url: 'https://npm.pkg.github.com'` to configure `.npmrc`
2. **Publish to GitHub Packages** — runs `npm publish` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`

Also adds `packages: write` permission to the workflow job.

The existing npmjs.com publish step is **untouched** — it continues to use OIDC trusted publishing.

## Files changed

- `.github/workflows/release.yml` — added `packages: write` permission + 2 new steps
- `CHANGELOG.md` — added entry under `[Unreleased]`

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (18/18)
- [ ] Verify package appears at https://github.com/exileum/meta-mcp/packages after next release
- [ ] Verify `npm install @exileum/meta-mcp --registry=https://npm.pkg.github.com` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package now publishes to GitHub Packages registry in addition to npm registry upon release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->