### PR TITLE
fix: add missing container status polling to threads_publish_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`threads_publish_image` skips container status polling before publishing** — added missing `waitForThreadsContainer()` call so image containers are polled for `FINISHED` status before publishing, matching the behavior of `threads_publish_video` and `threads_publish_carousel` and preventing intermittent publish failures for large images ([#29](https://github.com/exileum/meta-mcp/issues/29))
 - **Tenor GIF provider already sunset** — removed `TENOR` from `gif_provider` enum in `threads_publish_text` since Tenor API support was sunset by Meta on March 31, 2026; only GIPHY is currently supported ([#43](https://github.com/exileum/meta-mcp/issues/43))
 - **Instagram messaging tool descriptions reference wrong permission** — updated `ig_get_conversations` and `ig_send_message` descriptions to reference `instagram_business_manage_messages` (correct for Instagram API with Instagram Login) instead of the deprecated `instagram_manage_messages` (Messenger Platform) ([#23](https://github.com/exileum/meta-mcp/issues/23))
 

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -83,6 +83,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
         if (is_spoiler) params.is_spoiler_media = true;
         const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         const containerId = (container as { id: string }).id;
+        await waitForThreadsContainer(client, containerId);
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
           creation_id: containerId,
         });


### PR DESCRIPTION
## Summary

- `threads_publish_image` now polls container status before publishing, fixing intermittent failures for large images

Fixes #29

## What was broken

`threads_publish_image` created a media container and immediately called `threads_publish` without waiting for the container to reach `FINISHED` status. This caused intermittent publish failures, especially for large images or during peak API load, because the container hadn't finished processing yet.

Both `threads_publish_video` and `threads_publish_carousel` already correctly called `waitForThreadsContainer()` — only `threads_publish_image` was missing this step.

## What this PR does

Adds the missing `await waitForThreadsContainer(client, containerId)` call between container creation and publish in `threads_publish_image`, matching the pattern used by all other publishing tools.

## Files changed

- `src/tools/threads/publishing.ts` — added `waitForThreadsContainer()` call (1 line)
- `CHANGELOG.md` — added entry under `[Unreleased] > Fixed`

## Breaking changes

None.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 21 tests pass
- [x] Verified the fix matches the pattern in `threads_publish_video` (line 121) and `threads_publish_carousel` (line 160)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed intermittent image publishing failures on Threads by ensuring the image container completes processing before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->