### PR TITLE
fix: set media_type 'STORIES' for ig_publish_story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`ig_publish_story` missing `media_type: 'STORIES'`** — image stories had no `media_type` (defaulting to feed post) and video stories incorrectly used `"VIDEO"` instead of `"STORIES"`; now both set `media_type: "STORIES"` as required by Meta's Content Publishing API ([#50](https://github.com/exileum/meta-mcp/issues/50))
 - **`threads_publish_image` skips container status polling before publishing** — added missing `waitForThreadsContainer()` call so image containers are polled for `FINISHED` status before publishing, matching the behavior of `threads_publish_video` and `threads_publish_carousel` and preventing intermittent publish failures for large images ([#29](https://github.com/exileum/meta-mcp/issues/29))
 - **Tenor GIF provider already sunset** — removed `TENOR` from `gif_provider` enum in `threads_publish_text` since Tenor API support was sunset by Meta on March 31, 2026; only GIPHY is currently supported ([#43](https://github.com/exileum/meta-mcp/issues/43))
 - **Instagram messaging tool descriptions reference wrong permission** — updated `ig_get_conversations` and `ig_send_message` descriptions to reference `instagram_business_manage_messages` (correct for Instagram API with Instagram Login) instead of the deprecated `instagram_manage_messages` (Messenger Platform) ([#23](https://github.com/exileum/meta-mcp/issues/23))

--- a/src/tools/instagram/publishing.test.ts
+++ b/src/tools/instagram/publishing.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MetaClient } from "../../services/meta-client.js";
+import { registerIgPublishingTools } from "./publishing.js";
+
+/** Captures the tool handlers registered via server.tool() */
+function captureTools(server: McpServer) {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  vi.spyOn(server, "tool").mockImplementation(
+    (name: unknown, ..._rest: unknown[]) => {
+      // Last argument is always the handler function
+      const handler = _rest[_rest.length - 1];
+      handlers.set(name as string, handler as (...args: unknown[]) => unknown);
+    }
+  );
+  return handlers;
+}
+
+function makeMockClient(): MetaClient & { ig: ReturnType<typeof vi.fn> } {
+  const client = {
+    igUserId: "123456",
+    ig: vi.fn(async () => ({
+      data: { id: "container-1", status_code: "FINISHED" },
+      rateLimit: undefined,
+    })),
+  } as unknown as MetaClient & { ig: ReturnType<typeof vi.fn> };
+  return client;
+}
+
+describe("ig_publish_story", () => {
+  let handlers: Map<string, (...args: unknown[]) => unknown>;
+  let client: MetaClient & { ig: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    client = makeMockClient();
+    handlers = captureTools(server);
+    registerIgPublishingTools(server, client);
+  });
+
+  it("sets media_type STORIES for IMAGE stories", async () => {
+    const handler = handlers.get("ig_publish_story")!;
+    await handler({ media_type: "IMAGE", media_url: "https://example.com/photo.jpg" });
+
+    // First call is the container creation POST
+    const [method, path, params] = client.ig.mock.calls[0];
+    expect(method).toBe("POST");
+    expect(path).toBe("/123456/media");
+    expect(params).toMatchObject({
+      media_type: "STORIES",
+      image_url: "https://example.com/photo.jpg",
+    });
+    expect(params.video_url).toBeUndefined();
+  });
+
+  it("sets media_type STORIES for VIDEO stories", async () => {
+    const handler = handlers.get("ig_publish_story")!;
+    await handler({ media_type: "VIDEO", media_url: "https://example.com/video.mp4" });
+
+    const [method, path, params] = client.ig.mock.calls[0];
+    expect(method).toBe("POST");
+    expect(path).toBe("/123456/media");
+    expect(params).toMatchObject({
+      media_type: "STORIES",
+      video_url: "https://example.com/video.mp4",
+    });
+    expect(params.image_url).toBeUndefined();
+  });
+
+  it("never sets media_type to VIDEO for stories", async () => {
+    const handler = handlers.get("ig_publish_story")!;
+    await handler({ media_type: "VIDEO", media_url: "https://example.com/video.mp4" });
+
+    const [, , params] = client.ig.mock.calls[0];
+    expect(params.media_type).not.toBe("VIDEO");
+  });
+});

--- a/src/tools/instagram/publishing.ts
+++ b/src/tools/instagram/publishing.ts
@@ -174,12 +174,11 @@ export function registerIgPublishingTools(server: McpServer, client: MetaClient)
     },
     async ({ media_type, media_url }) => {
       try {
-        const params: Record<string, unknown> = {};
+        const params: Record<string, unknown> = { media_type: "STORIES" };
         if (media_type === "IMAGE") {
           params.image_url = media_url;
         } else {
           params.video_url = media_url;
-          params.media_type = "VIDEO";
         }
         const { data: container } = await client.ig("POST", `/${client.igUserId}/media`, params);
         const containerId = (container as { id: string }).id;


### PR DESCRIPTION
## Summary
- Fix `ig_publish_story` to always set `media_type: "STORIES"` for both image and video stories

## What was broken
`ig_publish_story` did not set `media_type` for image stories (causing them to default to feed posts) and incorrectly set `media_type: "VIDEO"` for video stories instead of `"STORIES"`.

## What this PR does
- Sets `media_type: "STORIES"` at the top of the params object, before the image/video branching
- Adds tests verifying correct `media_type` for both IMAGE and VIDEO stories
- Updates CHANGELOG

## Breaking changes
None.

## Files changed
- `src/tools/instagram/publishing.ts` — fix `media_type` in `ig_publish_story`
- `src/tools/instagram/publishing.test.ts` — new tests for story publishing params
- `CHANGELOG.md` — add entry under `[Unreleased]`

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `npm test` — all 24 tests pass
- [x] Verified IMAGE story params: `{ media_type: "STORIES", image_url }`
- [x] Verified VIDEO story params: `{ media_type: "STORIES", video_url }`
- [x] Confirmed no leftover `"VIDEO"` in story handler

Fixes #50