### PR TITLE
fix: poll carousel container status before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`ig_publish_carousel` calls `media_publish` before carousel container finishes processing** — added missing `waitForContainer()` call for the carousel container, matching the pattern used in all other Instagram publish tools; without it the Meta API returned error 9007 / subcode 2207027 ("Media ID is not available") when the container was still `IN_PROGRESS` ([#138](https://github.com/exileum/meta-mcp/issues/138))
 - **`topic_tag` silently accepted invalid characters in Threads publish tools** — added Zod `regex` validation rejecting periods (`.`) and ampersands (`&`) per Meta API docs; added comprehensive tests verifying `topic_tag` is correctly forwarded in all four Threads publish tools (text, image, video, carousel) and form-encoded correctly by MetaClient ([#137](https://github.com/exileum/meta-mcp/issues/137))
 
 ## [3.4.0] — 2026-04-05

--- a/src/tools/instagram/publishing.test.ts
+++ b/src/tools/instagram/publishing.test.ts
@@ -187,6 +187,47 @@ describe("waitForContainer", () => {
   });
 });
 
+describe("ig_publish_carousel", () => {
+  let server: ReturnType<typeof makeMockServer>;
+  let client: ReturnType<typeof makeParamMockClient>;
+
+  beforeEach(() => {
+    server = makeMockServer();
+    client = makeParamMockClient();
+    registerIgPublishingTools(server as never, client);
+  });
+
+  it("polls carousel container status before publishing", async () => {
+    const handler = server.tools.get("ig_publish_carousel")!;
+    await handler({
+      items: [
+        { type: "IMAGE", url: "https://example.com/a.jpg" },
+        { type: "IMAGE", url: "https://example.com/b.jpg" },
+      ],
+      caption: "test carousel",
+    });
+
+    const calls = (client.ig as ReturnType<typeof vi.fn>).mock.calls;
+    // Expected call sequence:
+    // 1. POST /{userId}/media (child 1 container)
+    // 2. GET /container-1 (poll child 1 status)
+    // 3. POST /{userId}/media (child 2 container)
+    // 4. GET /container-1 (poll child 2 status)
+    // 5. POST /{userId}/media (carousel container)
+    // 6. GET /container-1 (poll carousel status) <-- this was missing before the fix
+    // 7. POST /{userId}/media_publish
+    expect(calls.length).toBe(7);
+
+    // Verify the carousel container status poll (call index 5)
+    expect(calls[5][0]).toBe("GET");
+    expect(calls[5][2]).toEqual({ fields: "status_code" });
+
+    // Verify media_publish is the last call (call index 6)
+    expect(calls[6][0]).toBe("POST");
+    expect(calls[6][1]).toBe("/123/media_publish");
+  });
+});
+
 describe("ig_publish_video thumb_offset", () => {
   let server: ReturnType<typeof makeMockServer>;
   let client: ReturnType<typeof makeParamMockClient>;

--- a/src/tools/instagram/publishing.ts
+++ b/src/tools/instagram/publishing.ts
@@ -126,7 +126,9 @@ export function registerIgPublishingTools(server: McpServer, client: MetaClient)
         if (location_id) carouselParams.location_id = location_id;
         const { data: carousel } = await client.ig("POST", `/${client.igUserId}/media`, carouselParams);
         const carouselId = (carousel as { id: string }).id;
-        // Step 3: Publish
+        // Step 3: Wait for carousel container to be ready
+        await waitForContainer(client, carouselId);
+        // Step 4: Publish
         const { data, rateLimit } = await client.ig("POST", `/${client.igUserId}/media_publish`, {
           creation_id: carouselId,
         });


### PR DESCRIPTION
## Summary
- Added missing `waitForContainer()` call for the carousel container in `ig_publish_carousel`
- Added test verifying the carousel container is polled before `media_publish`

## What was broken
`ig_publish_carousel` called `media_publish` immediately after creating the carousel container, without waiting for it to finish processing. All other publish tools (`ig_publish_photo`, `ig_publish_video`, `ig_publish_reel`, `ig_publish_story`) correctly call `waitForContainer` before publishing. This caused Meta API error 9007 / subcode 2207027 ("Media ID is not available") when the carousel container was still `IN_PROGRESS`.

## What this PR does
Adds a single `await waitForContainer(client, carouselId)` call between carousel container creation and `media_publish` — matching the existing pattern in every other Instagram publish tool.

## Files changed
- `src/tools/instagram/publishing.ts` — added `waitForContainer` call for carousel container
- `src/tools/instagram/publishing.test.ts` — added test verifying carousel container polling
- `CHANGELOG.md` — documented the fix

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (70 tests, including new carousel polling test)
- [ ] Manual end-to-end test with real MCP server (not performed)

Fixes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)