### PR TITLE
feat(threads): publish text posts in a single API call via auto_publish_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`threads_publish_text` and `threads_reply` now publish text posts in a single API call by default** — both tools now pass `auto_publish_text=true` on the container-creation endpoint so the post is created **and** published in one HTTP request, instead of the previous two-step `POST /threads` → `POST /threads_publish` flow. This eliminates the `4279009` "container not propagated yet" race condition at its source (no second request → no propagation window) and saves one API round-trip per text post. A new optional `auto_publish` parameter (default `true`) is added to both tools as an escape hatch: set to `false` to force the legacy two-step flow. For `threads_reply`, the optimization only applies when the reply is text-only — replies with `image_url` or `video_url` continue to use the two-step flow with container polling for video. Only applicable to text posts per the [Threads Publishing API](https://developers.facebook.com/docs/threads/reference/publishing); image/video/carousel tools are unchanged.
+
 ## [3.8.0] — 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ npm run build
 
 | Tool | Description |
 |------|-------------|
-| `threads_publish_text` | Publish a text post (supports polls, GIFs, link attachments, topic tags, quote posts, spoiler flag, cross-share to IG Stories, text attachments up to 10K chars with styling) |
+| `threads_publish_text` | Publish a text post in a single API call (`auto_publish_text=true`, default; set `auto_publish=false` for the legacy two-step flow). Supports polls, GIFs, link attachments, topic tags, quote posts, spoiler flag, cross-share to IG Stories, text attachments up to 10K chars with styling |
 | `threads_publish_image` | Publish an image post (supports alt_text, topic tags, spoiler flag, cross-share to IG Stories) |
 | `threads_publish_video` | Publish a video post (supports alt_text, topic tags, spoiler flag, cross-share to IG Stories) |
 | `threads_publish_carousel` | Publish a carousel (2-20 items, supports alt_text per item, cross-share to IG Stories) |

--- a/llms.txt
+++ b/llms.txt
@@ -102,7 +102,7 @@ Only set variables for the platforms you use.
 - ig_get_message — Get message details
 
 ### Threads — Publishing (8)
-- threads_publish_text — Publish text post (polls, GIFs, link attachments, topic tags, quote, spoiler, cross-share to IG Stories, text attachments up to 10K chars with styling)
+- threads_publish_text — Publish text post in a single API call by default (auto_publish_text=true; set auto_publish=false for legacy two-step flow). Supports polls, GIFs, link attachments, topic tags, quote, spoiler, cross-share to IG Stories, text attachments up to 10K chars with styling
 - threads_publish_image — Publish image post (alt_text, topic tags, spoiler, cross-share to IG Stories)
 - threads_publish_video — Publish video post (alt_text, topic tags, spoiler, cross-share to IG Stories)
 - threads_publish_carousel — Publish carousel (2-20 items, alt_text per item, cross-share to IG Stories)
@@ -118,7 +118,7 @@ Only set variables for the platforms you use.
 
 ### Threads — Replies (4)
 - threads_get_replies — Get replies to a post (mode='top_level' default, or mode='full_tree' for the entire conversation flattened)
-- threads_reply — Reply to a post (supports image/video attachments)
+- threads_reply — Reply to a post. Text-only replies publish in a single API call by default (auto_publish_text=true); media replies (image/video) use the two-step flow
 - threads_hide_reply — Hide a reply
 - threads_unhide_reply — Unhide a reply
 

--- a/src/tools/threads/publishing.test.ts
+++ b/src/tools/threads/publishing.test.ts
@@ -883,6 +883,65 @@ describe("textAttachmentStylingSchema validation", () => {
   });
 });
 
+// ─── auto_publish (auto_publish_text=true shortcut) ─────────────────
+
+describe("threads_publish_text auto_publish", () => {
+  let server: ReturnType<typeof makeMockServer>;
+  let client: ReturnType<typeof makeParamMockClient>;
+
+  beforeEach(() => {
+    server = makeMockServer();
+    client = makeParamMockClient();
+    registerThreadsPublishingTools(server as never, client);
+  });
+
+  it("sends auto_publish_text=true and makes a single API call by default", async () => {
+    const handler = server.tools.get("threads_publish_text")!;
+    await handler({ text: "Hello" });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("POST");
+    expect(calls[0][1]).toBe("/threads-123/threads");
+    expect(calls[0][2]).toHaveProperty("auto_publish_text", true);
+  });
+
+  it("omits auto_publish_text and makes two calls when auto_publish=false", async () => {
+    const handler = server.tools.get("threads_publish_text")!;
+    await handler({ text: "Hello", auto_publish: false });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][2]).not.toHaveProperty("auto_publish_text");
+    expect(calls[1][0]).toBe("POST");
+    expect(calls[1][1]).toBe("/threads-123/threads_publish");
+    expect(calls[1][2]).toHaveProperty("creation_id", "container-1");
+  });
+
+  it("keeps auto_publish_text=true alongside advanced params (poll, link, topic_tag)", async () => {
+    const handler = server.tools.get("threads_publish_text")!;
+    await handler({
+      text: "Vote!",
+      poll_options: ["Yes", "No"],
+      link_attachment: "https://example.com",
+      topic_tag: "Polls",
+    });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][2]).toHaveProperty("auto_publish_text", true);
+    expect(calls[0][2]).toHaveProperty("poll_attachment");
+    expect(calls[0][2]).toHaveProperty("link_attachment", "https://example.com");
+    expect(calls[0][2]).toHaveProperty("topic_tag", "Polls");
+  });
+
+  it("returns the id from the single-call response (treated as the published post id)", async () => {
+    const handler = server.tools.get("threads_publish_text")!;
+    const result = await handler({ text: "Hello" }) as { content: Array<{ text: string }> };
+    expect(result.content[0].text).toContain("container-1");
+  });
+});
+
 describe("threads_repost", () => {
   let server: ReturnType<typeof makeMockServer>;
   let client: ReturnType<typeof makeParamMockClient>;

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -119,13 +119,15 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
         // invocation in tests). Only an explicit `false` takes the legacy path.
         const useAutoPublish = auto_publish !== false;
         if (useAutoPublish) params.auto_publish_text = true;
-        const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
-        if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
+        // `createResponse.id` is the published post id when useAutoPublish is true,
+        // and the unpublished container id otherwise.
+        const { data: createResponse, rateLimit: createRateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
+        if (typeof createResponse.id !== "string") throw new Error("Container creation did not return a valid id");
         if (useAutoPublish) {
-          return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
+          return { content: [{ type: "text", text: JSON.stringify({ ...createResponse, _rateLimit: createRateLimit }, null, 2) }] };
         }
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
-          creation_id: first.id,
+          creation_id: createResponse.id,
         });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -31,7 +31,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
   // ─── threads_publish_text ────────────────────────────────────
   server.tool(
     "threads_publish_text",
-    "Publish a text-only post on Threads. Supports optional link attachment, poll, GIF, topic tag, quote post, cross-share to Instagram Stories, and text_attachment for long-form content (up to 10,000 chars with optional styling and link). text_attachment cannot be combined with poll_options or link_attachment.",
+    "Publish a text-only post on Threads. By default publishes in a single API call via auto_publish_text=true (faster and avoids the 4279009 'container not propagated' race condition). Supports optional link attachment, poll, GIF, topic tag, quote post, cross-share to Instagram Stories, and text_attachment for long-form content (up to 10,000 chars with optional styling and link). text_attachment cannot be combined with poll_options or link_attachment. Set auto_publish=false to fall back to the legacy two-step create-then-publish flow.",
     {
       text: z.string().max(500).describe("Post text (max 500 chars)"),
       reply_control: z.enum(["everyone", "accounts_you_follow", "mentioned_only", "parent_post_author_only", "followers_only"]).optional().describe("Who can reply"),
@@ -47,8 +47,9 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
       text_attachment: z.string().min(1).max(10000).optional().describe("Long-form text attachment (max 10,000 chars). Renders as expandable 'Read more' block beneath the primary text. Cannot be combined with poll_options or link_attachment."),
       text_attachment_link: z.string().url().optional().describe("URL to include inside the text attachment card. Requires text_attachment."),
       text_attachment_styling: textAttachmentStylingSchema,
+      auto_publish: z.boolean().optional().default(true).describe("When true (default), combine container creation and publishing into a single API call via auto_publish_text=true — one HTTP request instead of two, and no risk of the 4279009 'container not propagated yet' race. Set to false to fall back to the legacy two-step flow (POST /threads, then POST /threads_publish)."),
     },
-    async ({ text, reply_control, link_attachment, topic_tag, quote_post_id, poll_options, gif_id, gif_provider, alt_text, is_spoiler, share_to_ig_story, text_attachment, text_attachment_link, text_attachment_styling }) => {
+    async ({ text, reply_control, link_attachment, topic_tag, quote_post_id, poll_options, gif_id, gif_provider, alt_text, is_spoiler, share_to_ig_story, text_attachment, text_attachment_link, text_attachment_styling, auto_publish }) => {
       try {
         // Validate mutual exclusions
         if (text_attachment && poll_options) {
@@ -113,11 +114,14 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
           params.text_attachment = JSON.stringify(obj);
         }
         applyShareToIgStory(params, share_to_ig_story);
-        const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
-        if (typeof container.id !== "string") throw new Error("Container creation did not return a valid id");
-        const containerId = container.id;
+        if (auto_publish) params.auto_publish_text = true;
+        const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
+        if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
+        if (auto_publish) {
+          return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
+        }
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
-          creation_id: containerId,
+          creation_id: first.id,
         });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -114,10 +114,14 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
           params.text_attachment = JSON.stringify(obj);
         }
         applyShareToIgStory(params, share_to_ig_story);
-        if (auto_publish) params.auto_publish_text = true;
+        // Treat `undefined` as the default (true) so the behavior is stable even
+        // if a caller bypasses Zod's schema-level default (e.g., direct handler
+        // invocation in tests). Only an explicit `false` takes the legacy path.
+        const useAutoPublish = auto_publish !== false;
+        if (useAutoPublish) params.auto_publish_text = true;
         const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
-        if (auto_publish) {
+        if (useAutoPublish) {
           return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
         }
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {

--- a/src/tools/threads/replies.test.ts
+++ b/src/tools/threads/replies.test.ts
@@ -104,3 +104,97 @@ describe("threads_get_replies mode", () => {
     expect(call[2]).not.toHaveProperty("after");
   });
 });
+
+// ─── threads_reply auto_publish (auto_publish_text=true shortcut) ────
+
+/** Mock client that returns a container id for POST /threads and FINISHED status for GET polls */
+function makePublishMockClient(): MetaClient {
+  return {
+    threadsUserId: "threads-123",
+    threads: vi.fn(async (method: string, _path: string) => {
+      if (method === "GET") {
+        return { data: { status: "FINISHED" }, rateLimit: undefined };
+      }
+      return { data: { id: "container-1" }, rateLimit: undefined };
+    }),
+  } as unknown as MetaClient;
+}
+
+describe("threads_reply auto_publish", () => {
+  it("text-only reply: sends auto_publish_text=true and makes a single API call by default", async () => {
+    const server = makeMockServer();
+    const client = makePublishMockClient();
+    registerThreadsReplyTools(server as never, client);
+
+    const handler = server.tools.get("threads_reply")!;
+    await handler({ reply_to_id: "post-42", text: "Hi" });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe("POST");
+    expect(calls[0][1]).toBe("/threads-123/threads");
+    expect(calls[0][2]).toHaveProperty("auto_publish_text", true);
+    expect(calls[0][2]).toHaveProperty("reply_to_id", "post-42");
+    expect(calls[0][2]).toHaveProperty("media_type", "TEXT");
+  });
+
+  it("text-only reply with auto_publish=false: omits auto_publish_text and makes two calls", async () => {
+    const server = makeMockServer();
+    const client = makePublishMockClient();
+    registerThreadsReplyTools(server as never, client);
+
+    const handler = server.tools.get("threads_reply")!;
+    await handler({ reply_to_id: "post-42", text: "Hi", auto_publish: false });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0][2]).not.toHaveProperty("auto_publish_text");
+    expect(calls[1][1]).toBe("/threads-123/threads_publish");
+    expect(calls[1][2]).toHaveProperty("creation_id", "container-1");
+  });
+
+  it("image reply: ignores auto_publish and always uses the two-step flow", async () => {
+    const server = makeMockServer();
+    const client = makePublishMockClient();
+    registerThreadsReplyTools(server as never, client);
+
+    const handler = server.tools.get("threads_reply")!;
+    await handler({
+      reply_to_id: "post-42",
+      text: "With image",
+      image_url: "https://example.com/photo.jpg",
+    });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    // Image: create container + publish (no status poll for images in threads_reply)
+    expect(calls).toHaveLength(2);
+    expect(calls[0][2]).not.toHaveProperty("auto_publish_text");
+    expect(calls[0][2]).toHaveProperty("media_type", "IMAGE");
+    expect(calls[0][2]).toHaveProperty("image_url", "https://example.com/photo.jpg");
+    expect(calls[1][1]).toBe("/threads-123/threads_publish");
+  });
+
+  it("video reply: ignores auto_publish, polls container, then publishes", async () => {
+    const server = makeMockServer();
+    const client = makePublishMockClient();
+    registerThreadsReplyTools(server as never, client);
+
+    const handler = server.tools.get("threads_reply")!;
+    await handler({
+      reply_to_id: "post-42",
+      text: "With video",
+      video_url: "https://example.com/clip.mp4",
+    });
+
+    const calls = (client.threads as ReturnType<typeof vi.fn>).mock.calls;
+    // Video: create container + GET status (FINISHED) + publish
+    expect(calls).toHaveLength(3);
+    expect(calls[0][0]).toBe("POST");
+    expect(calls[0][2]).not.toHaveProperty("auto_publish_text");
+    expect(calls[0][2]).toHaveProperty("media_type", "VIDEO");
+    expect(calls[1][0]).toBe("GET");
+    expect(calls[1][1]).toContain("container-1");
+    expect(calls[2][0]).toBe("POST");
+    expect(calls[2][1]).toBe("/threads-123/threads_publish");
+  });
+});

--- a/src/tools/threads/replies.ts
+++ b/src/tools/threads/replies.ts
@@ -46,14 +46,14 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
     },
     async ({ reply_to_id, text, image_url, video_url, auto_publish }) => {
       try {
-        const isTextOnly = !image_url && !video_url;
+        let mediaType = "TEXT";
+        if (image_url) mediaType = "IMAGE";
+        if (video_url) mediaType = "VIDEO";
+        const isTextOnly = mediaType === "TEXT";
         // Treat `undefined` as the default (true) so the behavior is stable even
         // if a caller bypasses Zod's schema-level default. Only an explicit `false`
         // forces the legacy two-step flow for text replies.
         const useAutoPublish = isTextOnly && auto_publish !== false;
-        let mediaType = "TEXT";
-        if (image_url) mediaType = "IMAGE";
-        if (video_url) mediaType = "VIDEO";
         const params: Record<string, unknown> = {
           media_type: mediaType,
           text,
@@ -62,16 +62,18 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
         if (image_url) params.image_url = image_url;
         if (video_url) params.video_url = video_url;
         if (useAutoPublish) params.auto_publish_text = true;
-        const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
-        if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
+        // `createResponse.id` is the published post id when useAutoPublish is true,
+        // and the unpublished container id otherwise.
+        const { data: createResponse, rateLimit: createRateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
+        if (typeof createResponse.id !== "string") throw new Error("Container creation did not return a valid id");
         if (useAutoPublish) {
-          return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
+          return { content: [{ type: "text", text: JSON.stringify({ ...createResponse, _rateLimit: createRateLimit }, null, 2) }] };
         }
         if (video_url) {
-          await waitForThreadsContainer(client, first.id);
+          await waitForThreadsContainer(client, createResponse.id);
         }
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
-          creation_id: first.id,
+          creation_id: createResponse.id,
         });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/replies.ts
+++ b/src/tools/threads/replies.ts
@@ -47,6 +47,10 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
     async ({ reply_to_id, text, image_url, video_url, auto_publish }) => {
       try {
         const isTextOnly = !image_url && !video_url;
+        // Treat `undefined` as the default (true) so the behavior is stable even
+        // if a caller bypasses Zod's schema-level default. Only an explicit `false`
+        // forces the legacy two-step flow for text replies.
+        const useAutoPublish = isTextOnly && auto_publish !== false;
         let mediaType = "TEXT";
         if (image_url) mediaType = "IMAGE";
         if (video_url) mediaType = "VIDEO";
@@ -57,10 +61,10 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
         };
         if (image_url) params.image_url = image_url;
         if (video_url) params.video_url = video_url;
-        if (isTextOnly && auto_publish) params.auto_publish_text = true;
+        if (useAutoPublish) params.auto_publish_text = true;
         const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
         if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
-        if (isTextOnly && auto_publish) {
+        if (useAutoPublish) {
           return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
         }
         if (video_url) {

--- a/src/tools/threads/replies.ts
+++ b/src/tools/threads/replies.ts
@@ -36,15 +36,17 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
   // ─── threads_reply ───────────────────────────────────────────
   server.tool(
     "threads_reply",
-    "Reply to a Threads post or another reply.",
+    "Reply to a Threads post or another reply. Text-only replies publish in a single API call by default (auto_publish_text=true); media replies always use the two-step create-then-publish flow.",
     {
       reply_to_id: z.string().describe("Post ID to reply to"),
       text: z.string().max(500).describe("Reply text"),
       image_url: httpsUrl.optional().describe("Optional image HTTPS URL to attach"),
       video_url: httpsUrl.optional().describe("Optional video HTTPS URL to attach"),
+      auto_publish: z.boolean().optional().default(true).describe("When true (default) and the reply is text-only (no image_url/video_url), combine container creation and publishing into a single API call via auto_publish_text=true — one HTTP request instead of two, and no risk of the 4279009 'container not propagated yet' race. Ignored for media replies. Set to false to force the legacy two-step flow for text replies."),
     },
-    async ({ reply_to_id, text, image_url, video_url }) => {
+    async ({ reply_to_id, text, image_url, video_url, auto_publish }) => {
       try {
+        const isTextOnly = !image_url && !video_url;
         let mediaType = "TEXT";
         if (image_url) mediaType = "IMAGE";
         if (video_url) mediaType = "VIDEO";
@@ -55,14 +57,17 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
         };
         if (image_url) params.image_url = image_url;
         if (video_url) params.video_url = video_url;
-        const { data: container } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
-        if (typeof container.id !== "string") throw new Error("Container creation did not return a valid id");
-        const containerId = container.id;
+        if (isTextOnly && auto_publish) params.auto_publish_text = true;
+        const { data: first, rateLimit: firstRate } = await client.threads("POST", `/${client.threadsUserId}/threads`, params);
+        if (typeof first.id !== "string") throw new Error("Container creation did not return a valid id");
+        if (isTextOnly && auto_publish) {
+          return { content: [{ type: "text", text: JSON.stringify({ ...first, _rateLimit: firstRate }, null, 2) }] };
+        }
         if (video_url) {
-          await waitForThreadsContainer(client, containerId);
+          await waitForThreadsContainer(client, first.id);
         }
         const { data, rateLimit } = await client.threads("POST", `/${client.threadsUserId}/threads_publish`, {
-          creation_id: containerId,
+          creation_id: first.id,
         });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {


### PR DESCRIPTION
## Summary

- Add an `auto_publish` option (default `true`) to `threads_publish_text` and `threads_reply` that sets `auto_publish_text=true` on the Threads container-creation endpoint so the post is created **and** published in a single HTTP request.
- Eliminates the `4279009` "container not propagated yet" race condition at its source — with only one request there is no gap for Meta's backend to fall out of sync between `create` and `publish`.
- Shaves one HTTP round-trip off every text post / text reply.

## Motivation

Today every text post goes through two requests:

1. `POST /{user}/threads` → returns a container id
2. `POST /{user}/threads_publish` with `creation_id`

Between those two calls Meta's backend sometimes hasn't finished propagating the fresh container, and step 2 fails with `error_subcode 4279009` (*"The requested resource does not exist / Cannot find media with the given ID"*). The usual workaround is a retry loop with exponential backoff — code that was in flight locally on this branch before this PR.

On 2025-06-04 Meta [added](https://developers.facebook.com/docs/threads/changelog) an `auto_publish_text` flag that eliminates the two-step flow for text posts:

> When this optional flag is passed, a Threads post is published automatically when a Threads media container is created without needing to go through the extra publish step. **Note: This only works for text posts.**
> — https://developers.facebook.com/docs/threads/reference/publishing

This PR wires that flag up and makes it the default for text paths, so we can delete the retry scaffolding instead of maintaining it.

## Scope

| Tool | Change |
|---|---|
| `threads_publish_text` | New `auto_publish?: boolean` (default `true`). When `true`, adds `auto_publish_text=true` to the payload and returns the response of the single `POST /threads` call. When `false`, falls back to the legacy two-step flow as an escape hatch. |
| `threads_reply` | Same new parameter. The flag is applied **only** when the reply is text-only (no `image_url`/`video_url`). Media replies continue to use the legacy two-step flow with `waitForThreadsContainer` for video. |
| `threads_publish_image` / `_video` / `_carousel` | **Unchanged.** Meta docs explicitly restrict `auto_publish_text` to text posts. |

## Response shape

Verified empirically (see test matrix): the `POST /{user}/threads` response with `auto_publish_text=true` contains the **published post id**, not a container id. This is the same shape that `POST /threads_publish` returns today, so downstream MCP clients see no change in the tool's response format — still `{ id, _rateLimit }`.

## Compatibility with advanced parameters

Meta docs do **not** document compatibility between `auto_publish_text` and `link_attachment` / `poll_attachment` / `text_attachment` / `topic_tag` / `reply_control` / `quote_post_id` / `gif_attachment` / `text_entities` / `is_ghost_post` / `enable_reply_approvals` / `reply_to_id`. The Postman collection only shows the flag used with a minimal text body.

Decision: trust the API and pass the flag unconditionally for TEXT containers. If Meta rejects some future combination we'll see it in real traffic and can add a whitelist then.

Verified end-to-end against a live test account before opening this PR:

| # | Combination | Published id | Read-back verification |
|---|---|---|---|
| 1 | Plain text (default `auto_publish=true`) | `18198560059348903` | `media_type=TEXT_POST`, permalink, timestamp ✅ |
| 2 | `+ link_attachment` | `17866322457527360` | `link_attachment_url` preserved ✅ |
| 3 | `+ poll_options` (2 options) | `18097582799053156` | `poll_attachment.option_a/option_b` preserved ✅ |
| 4 | `+ topic_tag` + `reply_control=mentioned_only` | `17981628581992630` | `topic_tag`, `reply_audience=MENTIONED_ONLY` preserved ✅ |
| 5 | `+ text_attachment` (long-form ~640 chars) | `18126226843604398` | published ✅ |
| 6 | `auto_publish=false` (legacy two-step) | `18427707631185412` | published ✅ (regression check) |

All six posts were deleted after verification. No `4279009` errors observed. No parameter-compatibility errors observed.

Not exercised in this matrix (require extra fixtures — left for opportunistic follow-up):
- `gif_id` (requires a valid GIPHY id)
- `quote_post_id` (requires a live post to quote)
- `share_to_ig_story` (requires a linked Instagram account)
- `threads_reply` text-only path (requires a live post to reply to)

## Test plan

- [x] `npm run build` — clean (TypeScript typecheck passes)
- [x] `npm test` — 159/159 passing, no regressions
- [x] Live end-to-end matrix against a real Threads account (six combinations, all posts deleted after verification)
- [x] Verified that the returned `id` is a real published post id by reading each back with `threads_get_post` — all returned `media_type=TEXT_POST` with valid `permalink` and `timestamp`
- [x] Verified the `auto_publish=false` fallback still reaches publication via the legacy two-step flow
- [ ] (post-merge, opportunistic) exercise `gif_id`, `quote_post_id`, `share_to_ig_story`, and the `threads_reply` text-only path in real traffic

## Related

Addresses the `auto_publish_text=true` item from the Threads API audit (`THREADS_API_AUDIT.md` §2.1, "Post to Threads" — previously marked ❌).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `auto_publish` (default: enabled) to text publishing and reply tools, allowing text posts and text-only replies to publish in a single step with immediate confirmation.

* **Bug Fixes**
  * Reduces propagation race that could cause publish errors by eliminating the second publish request for text-only flows.

* **Documentation**
  * Updated user docs and changelog to describe the new single-call default and the opt-out two-step option.

* **Tests**
  * Added tests covering auto-publish and legacy two-step behaviors for text and media replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->