### PR TITLE
chore(deps): update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "bin": {
         "meta-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.5.2",
+        "@types/node": "^25.6.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2",
-        "vitest": "^4.1.2"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=22"
@@ -2935,9 +2935,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
+    "@types/node": "^25.6.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- Updates all outdated dependencies to their latest versions (all patch/minor — no breaking changes)
- `zod`: 4.3.6 → 4.4.3
- `@types/node`: 25.5.2 → 25.6.0
- `typescript`: 6.0.2 → 6.0.3
- `vitest`: 4.1.2 → 4.1.5

`@modelcontextprotocol/sdk` (1.29.0) and `tsx` (4.21.0) were already on the latest versions.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (167 tests across 10 files)
- [x] `npm outdated` reports no remaining updates
- [x] `npm audit` reports 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and project dependencies to their latest compatible versions to improve stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->