### PR TITLE
fix: add 'shares' metric to threads_get_post_insights defaults (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Increased video container polling timeout from 30s to 120s** — `ig_publish_reel`, `ig_publish_story` (video), `threads_publish_video`, and video items inside `ig_publish_carousel` / `threads_publish_carousel` now wait up to 120 seconds for Meta to finish processing the video container, up from the previous 30-second default; photo operations remain at 30s; fixes timeouts on large video files (100 MB+) that need 40–90s of server-side transcoding
 - **Increased default polling interval from 2s to 5s** — `pollContainerStatus()` now checks container status every 5 seconds instead of every 2 seconds, reducing API call consumption by 60% during video processing (24 calls at 120s vs 60 previously); photo containers return FINISHED on the first poll so the longer interval has no practical impact on them
 
+### Fixed
+- **`threads_get_post_insights` missing `shares` metric in defaults** — added `shares` to the default metric list for `threads_get_post_insights` (now `views,likes,replies,reposts,quotes,shares`); per the [Threads Insights API docs](https://developers.facebook.com/docs/threads/insights/), `shares` is a valid post-level metric distinct from `reposts` (reposts = the repost action; shares = sharing the post to Instagram Stories, DMs, or external links). Sibling fix to #140 which previously corrected the same defaults string by removing the invalid `clicks` metric ([#115](https://github.com/exileum/meta-mcp/issues/115))
+
 ## [3.9.0] — 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ npm run build
 
 | Tool | Description |
 |------|-------------|
-| `threads_get_post_insights` | Get post analytics (views, likes, replies, reposts, quotes) |
+| `threads_get_post_insights` | Get post analytics (views, likes, replies, reposts, quotes, shares) |
 | `threads_get_user_insights` | Get account-level analytics (period: day/lifetime; `since`/`until` required for `day`) |
 
 ## Resources

--- a/llms.txt
+++ b/llms.txt
@@ -130,7 +130,7 @@ Only set variables for the platforms you use.
 - threads_get_user_threads — List user's threads
 
 ### Threads — Insights (2)
-- threads_get_post_insights — Post analytics (views, likes, replies, reposts, quotes)
+- threads_get_post_insights — Post analytics (views, likes, replies, reposts, quotes, shares)
 - threads_get_user_insights — Account-level analytics (period: day/lifetime)
 
 ## Resources

--- a/src/tools/threads/insights.test.ts
+++ b/src/tools/threads/insights.test.ts
@@ -21,7 +21,7 @@ function makeMockClient(response: unknown = { data: [] }): MetaClient {
 }
 
 describe("threads_get_post_insights", () => {
-  it("defaults to valid post-level metrics (no clicks)", async () => {
+  it("defaults to all valid post-level metrics including shares", async () => {
     const client = makeMockClient();
     registeredTools.clear();
     registerThreadsInsightTools(mockServer, client);
@@ -30,7 +30,7 @@ describe("threads_get_post_insights", () => {
     await handler({ post_id: "post-456" } as Record<string, unknown>);
 
     expect(client.threads).toHaveBeenCalledWith("GET", "/post-456/insights", {
-      metric: "views,likes,replies,reposts,quotes",
+      metric: "views,likes,replies,reposts,quotes,shares",
     });
   });
 

--- a/src/tools/threads/insights.test.ts
+++ b/src/tools/threads/insights.test.ts
@@ -21,7 +21,7 @@ function makeMockClient(response: unknown = { data: [] }): MetaClient {
 }
 
 describe("threads_get_post_insights", () => {
-  it("defaults to all valid post-level metrics including shares", async () => {
+  it("includes shares in default post-level metrics", async () => {
     const client = makeMockClient();
     registeredTools.clear();
     registerThreadsInsightTools(mockServer, client);

--- a/src/tools/threads/insights.ts
+++ b/src/tools/threads/insights.ts
@@ -6,14 +6,14 @@ export function registerThreadsInsightTools(server: McpServer, client: MetaClien
   // ─── threads_get_post_insights ───────────────────────────────
   server.tool(
     "threads_get_post_insights",
-    "Get insights/analytics for a specific Threads post (views, likes, replies, reposts, quotes).",
+    "Get insights/analytics for a specific Threads post (views, likes, replies, reposts, quotes, shares).",
     {
       post_id: z.string().describe("Threads post ID"),
-      metric: z.string().optional().describe("Comma-separated metrics (default: views,likes,replies,reposts,quotes)"),
+      metric: z.string().optional().describe("Comma-separated metrics (default: views,likes,replies,reposts,quotes,shares)"),
     },
     async ({ post_id, metric }) => {
       try {
-        const m = metric || "views,likes,replies,reposts,quotes";
+        const m = metric || "views,likes,replies,reposts,quotes,shares";
         const { data, rateLimit } = await client.threads("GET", `/${post_id}/insights`, { metric: m });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {

--- a/src/tools/threads/insights.ts
+++ b/src/tools/threads/insights.ts
@@ -2,18 +2,20 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MetaClient } from "../../services/meta-client.js";
 
+const POST_INSIGHTS_DEFAULT_METRICS = "views,likes,replies,reposts,quotes,shares";
+
 export function registerThreadsInsightTools(server: McpServer, client: MetaClient): void {
   // ─── threads_get_post_insights ───────────────────────────────
   server.tool(
     "threads_get_post_insights",
-    "Get insights/analytics for a specific Threads post (views, likes, replies, reposts, quotes, shares).",
+    `Get insights/analytics for a specific Threads post (${POST_INSIGHTS_DEFAULT_METRICS.replaceAll(",", ", ")}).`,
     {
       post_id: z.string().describe("Threads post ID"),
-      metric: z.string().optional().describe("Comma-separated metrics (default: views,likes,replies,reposts,quotes,shares)"),
+      metric: z.string().optional().describe(`Comma-separated metrics (default: ${POST_INSIGHTS_DEFAULT_METRICS})`),
     },
     async ({ post_id, metric }) => {
       try {
-        const m = metric || "views,likes,replies,reposts,quotes,shares";
+        const m = metric || POST_INSIGHTS_DEFAULT_METRICS;
         const { data, rateLimit } = await client.threads("GET", `/${post_id}/insights`, { metric: m });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {


### PR DESCRIPTION
## Summary

Adds the missing `shares` metric to the default metric list for `threads_get_post_insights`. Per the [official Threads Insights docs](https://developers.facebook.com/docs/threads/insights/), `shares` is a valid post-level metric distinct from `reposts`:

- `reposts` = the Threads repost action (Twitter-style retweet)
- `shares` = sharing the post to Instagram Stories, DMs, or external links

## What was broken

`src/tools/threads/insights.ts:16` set the default metric to `"views,likes,replies,reposts,quotes"`, omitting `shares`. Callers that didn't pass an explicit `metric` argument silently lost share counts in the response.

> **Note on the issue body:** Issue #115 quotes the default as `"views,likes,replies,reposts,quotes,clicks"`. That snapshot predates #140, which already removed `clicks` (it is user-level only). The current default just before this PR is `"views,likes,replies,reposts,quotes"`, and this PR appends `shares` to it. So this is a sibling fix to #140 — both correct the same defaults string against the same documented API.

## What this PR does

- `src/tools/threads/insights.ts` — change the default metric to `"views,likes,replies,reposts,quotes,shares"`; update the tool top-level description and the `metric` parameter description so they mirror the new default.
- `src/tools/threads/insights.test.ts` — update the existing default-metric assertion (and the surrounding `it()` description) to expect `shares`.
- `README.md`, `llms.txt` — update the user-facing tool description so it lists `shares`.
- `CHANGELOG.md` — add a `### Fixed` entry under `[Unreleased]` linking #115 and cross-referencing the #140 sibling fix.

`threads_get_user_insights` is intentionally untouched: per the same docs, `shares` is **not** a valid user-level metric (the user-level set is `views,likes,replies,reposts,quotes,clicks,followers_count,follower_demographics`).

## Breaking changes

None. The default response will simply include one additional metric (`shares`) for callers that don't pass an explicit `metric` argument. Callers that pass an explicit `metric` are unaffected.

## Files changed

- `src/tools/threads/insights.ts`
- `src/tools/threads/insights.test.ts`
- `README.md`
- `llms.txt`
- `CHANGELOG.md`

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm test` — all 167 tests pass; the updated default-metric assertion now expects `shares`
- [x] Verified twice against the official Threads Insights docs that `shares` is a valid post-level metric and is documented as distinct from `reposts`
- [x] `git grep` — no stale `views,likes,replies,reposts,quotes` references remain in the post-level path; the user-level mentions of that prefix (which intentionally include `clicks` and exclude `shares`) are untouched
- [ ] Live MCP end-to-end test was not performed (skipped at request)

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)