### PR TITLE
fix: ig_get_media_insights default metrics fail on non-Reel media (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Increased video container polling timeout from 30s to 120s** — `ig_publish_reel`, `ig_publish_story` (video), `threads_publish_video`, and video items inside `ig_publish_carousel` / `threads_publish_carousel` now wait up to 120 seconds for Meta to finish processing the video container, up from the previous 30-second default; photo operations remain at 30s; fixes timeouts on large video files (100 MB+) that need 40–90s of server-side transcoding
 - **Increased default polling interval from 2s to 5s** — `pollContainerStatus()` now checks container status every 5 seconds instead of every 2 seconds, reducing API call consumption by 60% during video processing (24 calls at 120s vs 60 previously); photo containers return FINISHED on the first poll so the longer interval has no practical impact on them
 
+### Fixed
+- **`ig_get_media_insights` default metrics fail on non-Reel media types** — changed the default `metric` from `views,reach,saved,shares` to `views,reach`, the only set documented and confirmed safe for IMAGE, VIDEO, REEL, CAROUSEL, and STORY; previously the default could trigger `(#100) The metric ... is not supported for this media type` (e.g. `shares` on IMAGE, `saved` on STORY) per the [Instagram Media Insights API](https://developers.facebook.com/docs/instagram-platform/reference/instagram-media/insights/); the tool description now lists the valid metrics per media type so callers can opt into richer insights explicitly ([#120](https://github.com/exileum/meta-mcp/issues/120))
+
 ## [3.9.0] — 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npm run build
 | `ig_get_media_list` | List published media |
 | `ig_get_media` | Get media details |
 | `ig_delete_media` | Delete a media post (requires Facebook Login) |
-| `ig_get_media_insights` | Get media analytics (views, reach, saved, shares) |
+| `ig_get_media_insights` | Get media analytics (default views, reach — override `metric` per media type) |
 | `ig_toggle_comments` | Enable/disable comments on a post |
 
 ### Instagram — Comments (7)

--- a/llms.txt
+++ b/llms.txt
@@ -66,7 +66,7 @@ Only set variables for the platforms you use.
 - ig_get_media_list — List published media
 - ig_get_media — Get media details
 - ig_delete_media — Delete a media post (Facebook Login only)
-- ig_get_media_insights — Get media analytics (views, reach, saved, shares)
+- ig_get_media_insights — Get media analytics (default views, reach — override `metric` per media type)
 - ig_toggle_comments — Enable/disable comments on a post
 
 ### Instagram — Comments (7)

--- a/src/tools/instagram/media.test.ts
+++ b/src/tools/instagram/media.test.ts
@@ -56,3 +56,31 @@ describe("ig_get_media_list limit=0", () => {
     expect(call[2]).toHaveProperty("limit", 50);
   });
 });
+
+describe("ig_get_media_insights default metric", () => {
+  let server: ReturnType<typeof makeMockServer>;
+  let client: ReturnType<typeof makeMockClient>;
+
+  beforeEach(() => {
+    server = makeMockServer();
+    client = makeMockClient();
+    registerIgMediaTools(server as never, client);
+  });
+
+  it("uses views,reach as default when no metric is provided", async () => {
+    const handler = server.tools.get("ig_get_media_insights")!;
+    await handler({ media_id: "media_1" });
+
+    const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]).toBe("/media_1/insights");
+    expect(call[2]).toEqual({ metric: "views,reach" });
+  });
+
+  it("passes through caller-provided metric verbatim", async () => {
+    const handler = server.tools.get("ig_get_media_insights")!;
+    await handler({ media_id: "media_2", metric: "views,reach,likes,comments,shares,reposts,reels_skip_rate" });
+
+    const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toEqual({ metric: "views,reach,likes,comments,shares,reposts,reels_skip_rate" });
+  });
+});

--- a/src/tools/instagram/media.test.ts
+++ b/src/tools/instagram/media.test.ts
@@ -81,6 +81,7 @@ describe("ig_get_media_insights default metric", () => {
     await handler({ media_id: "media_2", metric: "views,reach,likes,comments,shares,reposts,reels_skip_rate" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]).toBe("/media_2/insights");
     expect(call[2]).toEqual({ metric: "views,reach,likes,comments,shares,reposts,reels_skip_rate" });
   });
 });

--- a/src/tools/instagram/media.ts
+++ b/src/tools/instagram/media.ts
@@ -68,7 +68,7 @@ export function registerIgMediaTools(server: McpServer, client: MetaClient): voi
   server.tool(
     "ig_get_media_insights",
     "Get insights/analytics for a specific media post. Default metrics 'views,reach' are safe for every media type. Metric availability differs by media type — request more selectively to avoid (#100) errors:\n" +
-      "- IMAGE / VIDEO / CAROUSEL: views, reach, saved, total_interactions, likes, comments (note: 'shares' may fail with (#100) on IMAGE per issue #120 — test before relying on it)\n" +
+      "- IMAGE / VIDEO / CAROUSEL: views, reach, saved, total_interactions, likes, comments (note: 'shares' may return (#100) on IMAGE — test before relying on it)\n" +
       "- REEL: views, reach, saved, total_interactions, likes, comments, shares, reposts, reels_skip_rate\n" +
       "- STORY: views, reach, total_interactions, navigation, replies, profile_activity, profile_visits, follows\n" +
       "Note: 'impressions' and 'video_views' were deprecated in v22.0 — use 'views' instead. See https://developers.facebook.com/docs/instagram-platform/reference/instagram-media/insights/ for the authoritative per-type matrix.",

--- a/src/tools/instagram/media.ts
+++ b/src/tools/instagram/media.ts
@@ -68,7 +68,7 @@ export function registerIgMediaTools(server: McpServer, client: MetaClient): voi
   server.tool(
     "ig_get_media_insights",
     "Get insights/analytics for a specific media post. Default metrics 'views,reach' are safe for every media type. Metric availability differs by media type — request more selectively to avoid (#100) errors:\n" +
-      "- IMAGE / VIDEO / CAROUSEL: views, reach, saved, total_interactions (and likes/comments/shares per the API matrix)\n" +
+      "- IMAGE / VIDEO / CAROUSEL: views, reach, saved, total_interactions, likes, comments (note: 'shares' may fail with (#100) on IMAGE per issue #120 — test before relying on it)\n" +
       "- REEL: views, reach, saved, total_interactions, likes, comments, shares, reposts, reels_skip_rate\n" +
       "- STORY: views, reach, total_interactions, navigation, replies, profile_activity, profile_visits, follows\n" +
       "Note: 'impressions' and 'video_views' were deprecated in v22.0 — use 'views' instead. See https://developers.facebook.com/docs/instagram-platform/reference/instagram-media/insights/ for the authoritative per-type matrix.",

--- a/src/tools/instagram/media.ts
+++ b/src/tools/instagram/media.ts
@@ -67,14 +67,18 @@ export function registerIgMediaTools(server: McpServer, client: MetaClient): voi
   // ─── ig_get_media_insights ───────────────────────────────────
   server.tool(
     "ig_get_media_insights",
-    "Get insights/analytics for a specific media post. Note: 'impressions' and 'video_views' were deprecated in v22.0 — use 'views' instead. Available metrics: views, reach, saved, shares, likes, comments, reposts, reels_skip_rate.",
+    "Get insights/analytics for a specific media post. Default metrics 'views,reach' are safe for every media type. Metric availability differs by media type — request more selectively to avoid (#100) errors:\n" +
+      "- IMAGE / VIDEO / CAROUSEL: views, reach, saved, total_interactions (and likes/comments/shares per the API matrix)\n" +
+      "- REEL: views, reach, saved, total_interactions, likes, comments, shares, reposts, reels_skip_rate\n" +
+      "- STORY: views, reach, total_interactions, navigation, replies, profile_activity, profile_visits, follows\n" +
+      "Note: 'impressions' and 'video_views' were deprecated in v22.0 — use 'views' instead. See https://developers.facebook.com/docs/instagram-platform/reference/instagram-media/insights/ for the authoritative per-type matrix.",
     {
       media_id: z.string().describe("Media ID"),
-      metric: z.string().optional().describe("Comma-separated metrics (default: views,reach,saved,shares). For REEL add: likes,comments,reposts,reels_skip_rate"),
+      metric: z.string().optional().describe("Comma-separated metrics. Default 'views,reach' is universally supported; override per media type per the tool description."),
     },
     async ({ media_id, metric }) => {
       try {
-        const m = metric || "views,reach,saved,shares";
+        const m = metric || "views,reach";
         const { data, rateLimit } = await client.ig("GET", `/${media_id}/insights`, { metric: m });
         return { content: [{ type: "text", text: JSON.stringify({ ...data, _rateLimit: rateLimit }, null, 2) }] };
       } catch (error) {


### PR DESCRIPTION
## Summary

- Flips the default `metric` of `ig_get_media_insights` from `views,reach,saved,shares` to `views,reach` so it stops returning `(#100) The metric ... is not supported for this media type` on IMAGE / VIDEO / CAROUSEL / STORY posts.
- Rewrites the tool description with a per-media-type metric matrix so callers can opt into richer insights explicitly.
- Adds unit tests for the new default and for caller-supplied metric pass-through.

Fixes #120

## What was broken

`ig_get_media_insights` defaulted to four metrics, two of which are not universal:

- `saved` is unsupported on STORY.
- `shares` is empirically rejected on at least IMAGE posts with `(#100) The metric shares is not supported for this media type` per the issue's reproducer (Meta's docs claim broader support, but the API call fails).

Result: a default call on the most common content types (IMAGE, CAROUSEL, STORY) failed outright instead of returning the metrics that *are* available — bad UX for an opt-out parameter.

## What this PR does

- `src/tools/instagram/media.ts` — default `metric` becomes `views,reach`; description rewritten to enumerate which metrics are valid per media type and to link the [Instagram Media Insights API](https://developers.facebook.com/docs/instagram-platform/reference/instagram-media/insights/) for the authoritative matrix.
- `src/tools/instagram/media.test.ts` — adds two tests paralleling the existing `ig_get_media_list limit=0` pattern: default-metric assertion and caller-override pass-through.
- `README.md`, `llms.txt` — synced one-line tool descriptions.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry referencing the issue and the docs.

## Breaking changes

None. The `metric` parameter remains optional with the same shape; callers passing an explicit value get identical behaviour. Only the default changes — and the previous default was producing API errors, so any caller relying on the old default was already broken.

## Files changed

- `src/tools/instagram/media.ts`
- `src/tools/instagram/media.test.ts`
- `README.md`
- `llms.txt`
- `CHANGELOG.md`

## Test plan

- [x] `npm run build` passes (clean tsc compile)
- [x] `npm test` passes (10 files, 169 tests, including 2 new for `ig_get_media_insights`)
- [x] Grep sweep: no remaining `views,reach,saved,shares` source/doc references outside the intentional CHANGELOG citation
- [ ] Live MCP end-to-end test was **not** performed (skipped per maintainer request); unit tests confirm the default flip and override pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)