### PR TITLE
chore: add Dockerfile HEALTHCHECK and OCI LABEL metadata (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Dockerfile now declares OCI image metadata and a `HEALTHCHECK`** — added `org.opencontainers.image.{title,description,source,url,documentation,licenses}` labels so registries (GHCR, Docker Hub) link the image back to the repo, scanners can match CVEs to the source, and image catalogs render description/license correctly; added a process-level `HEALTHCHECK` (`pidof node`) that lets Docker / Compose / ECS report container health for this stdio-based MCP server (no HTTP surface to probe) ([#111](https://github.com/exileum/meta-mcp/issues/111))
 - **Increased video container polling timeout from 30s to 120s** — `ig_publish_reel`, `ig_publish_story` (video), `threads_publish_video`, and video items inside `ig_publish_carousel` / `threads_publish_carousel` now wait up to 120 seconds for Meta to finish processing the video container, up from the previous 30-second default; photo operations remain at 30s; fixes timeouts on large video files (100 MB+) that need 40–90s of server-side transcoding
 - **Increased default polling interval from 2s to 5s** — `pollContainerStatus()` now checks container status every 5 seconds instead of every 2 seconds, reducing API call consumption by 60% during video processing (24 calls at 120s vs 60 previously); photo containers return FINISHED on the first poll so the longer interval has no practical impact on them
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ COPY --chown=app:app dist/ ./dist/
 USER app
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD pidof node || exit 1
+  CMD pidof node
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM node:22-alpine
+
+LABEL org.opencontainers.image.title="meta-mcp" \
+      org.opencontainers.image.description="Enables AI assistants to manage Instagram and Threads accounts — publish content, handle comments, view insights, search hashtags, and manage DMs through the Meta Graph API" \
+      org.opencontainers.image.source="https://github.com/exileum/meta-mcp" \
+      org.opencontainers.image.url="https://github.com/exileum/meta-mcp" \
+      org.opencontainers.image.documentation="https://github.com/exileum/meta-mcp#readme" \
+      org.opencontainers.image.licenses="MIT"
+
 WORKDIR /app
 
 RUN addgroup -S app && adduser -S app -G app && chown app:app /app
@@ -9,4 +17,8 @@ ENV NODE_ENV=production
 COPY --chown=app:app dist/ ./dist/
 
 USER app
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD pidof node || exit 1
+
 ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Adds OCI image labels and a `HEALTHCHECK` directive to the `Dockerfile` so registries, scanners, and orchestrators can interpret the image correctly.

## What was broken

The previous `Dockerfile` had:
- **No OCI labels** — registries like GHCR could not link the image back to the source repo, vulnerability scanners had no metadata to correlate CVEs against, and image catalogs displayed no description or license.
- **No `HEALTHCHECK`** — Docker Compose, ECS, k8s, etc. could not determine container health and always reported the container as `running` regardless of the actual state of the Node.js process.

## What this PR does

1. **Six OCI image labels** placed right after `FROM node:22-alpine` so they live in an early, stable cache layer:

   - `org.opencontainers.image.title` = `meta-mcp`
   - `org.opencontainers.image.description` = the same description as `package.json` / `server.json`
   - `org.opencontainers.image.source` = `https://github.com/exileum/meta-mcp`
   - `org.opencontainers.image.url` = same GitHub URL (homepage)
   - `org.opencontainers.image.documentation` = `https://github.com/exileum/meta-mcp#readme`
   - `org.opencontainers.image.licenses` = `MIT`

2. **`HEALTHCHECK`** added before `ENTRYPOINT`:

   ```dockerfile
   HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD pidof node || exit 1
   ```

   Since this is a stdio-based MCP server, there is no HTTP endpoint to probe — a process-level check is the right fit. `pidof` is supplied by busybox in `node:22-alpine` and needs no extra `apk add`.

## Design choices

- **Version label omitted intentionally.** Adding `org.opencontainers.image.version` would create yet another place to bump on release; #39 explicitly removed hard-coded versions from the repo. Consumers can still set it at build time with `docker build --label org.opencontainers.image.version=...`.
- **`pidof` over `pgrep`.** Both are provided by busybox, but `pgrep -x` (suggested in the issue body) has portability quirks across busybox builds. `pidof node` is unambiguous and well-supported.

## Files changed

- `Dockerfile` — six `LABEL`s after `FROM`, one `HEALTHCHECK` before `ENTRYPOINT`. No structural changes elsewhere.
- `CHANGELOG.md` — `[Unreleased] / Changed` entry, matching the precedent set by the #35/#36 Dockerfile work in 3.7.0.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 167 tests pass.
- [x] `docker build .` — succeeds end-to-end on `node:22-alpine`.
- [x] `docker inspect` — confirms all six labels under `.Config.Labels` and the full healthcheck spec under `.Config.Healthcheck`.
- [x] Live container — `docker run -d -i meta-mcp-test:111` reaches `Status: "healthy"` after the start period (`pidof node` exit 0, output `1` for PID 1).
- [ ] Reviewer to spot-check the label set if any extras (e.g., `created`, `revision`, `vendor`) are wanted later.

Fixes #111