### PR TITLE
fix: align pagination cursor tests with new test-utils + Zod-default mock

### DIFF
--- a/src/tools/instagram/comments.test.ts
+++ b/src/tools/instagram/comments.test.ts
@@ -108,8 +108,7 @@ describe("ig_get_comments pagination cursors", () => {
   });
 
   it("omits both cursors when neither is provided", async () => {
-    const handler = server.tools.get("ig_get_comments")!;
-    await handler({ media_id: "media_1" });
+    await server.callTool("ig_get_comments", { media_id: "media_1" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).not.toHaveProperty("after");
@@ -117,8 +116,7 @@ describe("ig_get_comments pagination cursors", () => {
   });
 
   it("forwards before cursor when provided alone", async () => {
-    const handler = server.tools.get("ig_get_comments")!;
-    await handler({ media_id: "media_1", before: "cursor-prev" });
+    await server.callTool("ig_get_comments", { media_id: "media_1", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ before: "cursor-prev" });
@@ -126,8 +124,7 @@ describe("ig_get_comments pagination cursors", () => {
   });
 
   it("forwards both cursors when both are provided", async () => {
-    const handler = server.tools.get("ig_get_comments")!;
-    await handler({ media_id: "media_1", after: "cursor-next", before: "cursor-prev" });
+    await server.callTool("ig_get_comments", { media_id: "media_1", after: "cursor-next", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ after: "cursor-next", before: "cursor-prev" });
@@ -145,8 +142,7 @@ describe("ig_get_replies pagination cursors", () => {
   });
 
   it("omits both cursors when neither is provided", async () => {
-    const handler = server.tools.get("ig_get_replies")!;
-    await handler({ comment_id: "c_1" });
+    await server.callTool("ig_get_replies", { comment_id: "c_1" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).not.toHaveProperty("after");
@@ -154,8 +150,7 @@ describe("ig_get_replies pagination cursors", () => {
   });
 
   it("forwards before cursor when provided alone", async () => {
-    const handler = server.tools.get("ig_get_replies")!;
-    await handler({ comment_id: "c_1", before: "cursor-prev" });
+    await server.callTool("ig_get_replies", { comment_id: "c_1", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ before: "cursor-prev" });
@@ -163,8 +158,7 @@ describe("ig_get_replies pagination cursors", () => {
   });
 
   it("forwards both cursors when both are provided", async () => {
-    const handler = server.tools.get("ig_get_replies")!;
-    await handler({ comment_id: "c_1", after: "cursor-next", before: "cursor-prev" });
+    await server.callTool("ig_get_replies", { comment_id: "c_1", after: "cursor-next", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ after: "cursor-next", before: "cursor-prev" });

--- a/src/tools/instagram/mentions.test.ts
+++ b/src/tools/instagram/mentions.test.ts
@@ -96,8 +96,7 @@ describe("ig_get_tagged_media pagination cursors", () => {
   });
 
   it("omits both cursors when neither is provided", async () => {
-    const handler = server.tools.get("ig_get_tagged_media")!;
-    await handler({});
+    await server.callTool("ig_get_tagged_media", {});
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).not.toHaveProperty("after");
@@ -105,8 +104,7 @@ describe("ig_get_tagged_media pagination cursors", () => {
   });
 
   it("forwards before cursor when provided alone", async () => {
-    const handler = server.tools.get("ig_get_tagged_media")!;
-    await handler({ before: "cursor-prev" });
+    await server.callTool("ig_get_tagged_media", { before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ before: "cursor-prev" });
@@ -114,8 +112,7 @@ describe("ig_get_tagged_media pagination cursors", () => {
   });
 
   it("forwards both cursors when both are provided", async () => {
-    const handler = server.tools.get("ig_get_tagged_media")!;
-    await handler({ after: "cursor-next", before: "cursor-prev" });
+    await server.callTool("ig_get_tagged_media", { after: "cursor-next", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ after: "cursor-next", before: "cursor-prev" });

--- a/src/tools/instagram/messaging.test.ts
+++ b/src/tools/instagram/messaging.test.ts
@@ -112,8 +112,7 @@ describe("ig_get_conversations pagination cursors", () => {
   });
 
   it("omits both cursors when neither is provided", async () => {
-    const handler = server.tools.get("ig_get_conversations")!;
-    await handler({});
+    await server.callTool("ig_get_conversations", {});
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).not.toHaveProperty("after");
@@ -121,8 +120,7 @@ describe("ig_get_conversations pagination cursors", () => {
   });
 
   it("forwards before cursor when provided alone", async () => {
-    const handler = server.tools.get("ig_get_conversations")!;
-    await handler({ before: "cursor-prev" });
+    await server.callTool("ig_get_conversations", { before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ before: "cursor-prev" });
@@ -130,8 +128,7 @@ describe("ig_get_conversations pagination cursors", () => {
   });
 
   it("forwards both cursors when both are provided", async () => {
-    const handler = server.tools.get("ig_get_conversations")!;
-    await handler({ after: "cursor-next", before: "cursor-prev" });
+    await server.callTool("ig_get_conversations", { after: "cursor-next", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ after: "cursor-next", before: "cursor-prev" });
@@ -149,8 +146,7 @@ describe("ig_get_messages pagination cursors", () => {
   });
 
   it("omits both cursors when neither is provided", async () => {
-    const handler = server.tools.get("ig_get_messages")!;
-    await handler({ conversation_id: "conv_1" });
+    await server.callTool("ig_get_messages", { conversation_id: "conv_1" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).not.toHaveProperty("after");
@@ -158,8 +154,7 @@ describe("ig_get_messages pagination cursors", () => {
   });
 
   it("forwards before cursor when provided alone", async () => {
-    const handler = server.tools.get("ig_get_messages")!;
-    await handler({ conversation_id: "conv_1", before: "cursor-prev" });
+    await server.callTool("ig_get_messages", { conversation_id: "conv_1", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ before: "cursor-prev" });
@@ -167,8 +162,7 @@ describe("ig_get_messages pagination cursors", () => {
   });
 
   it("forwards both cursors when both are provided", async () => {
-    const handler = server.tools.get("ig_get_messages")!;
-    await handler({ conversation_id: "conv_1", after: "cursor-next", before: "cursor-prev" });
+    await server.callTool("ig_get_messages", { conversation_id: "conv_1", after: "cursor-next", before: "cursor-prev" });
 
     const call = (client.ig as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ after: "cursor-next", before: "cursor-prev" });

--- a/src/tools/instagram/profile.test.ts
+++ b/src/tools/instagram/profile.test.ts
@@ -10,7 +10,8 @@ function makeMockServer() {
     tools,
     schemas,
     tool: vi.fn((name: string, _desc: string, schema: z.ZodRawShape, handler: (...args: unknown[]) => unknown) => {
-      tools.set(name, handler);
+      const parsed = z.object(schema);
+      tools.set(name, async (args: Record<string, unknown> = {}) => handler(parsed.parse(args)));
       schemas.set(name, schema);
     }),
   };


### PR DESCRIPTION
## Summary

Three Instagram test files (\`comments.test.ts\`, \`mentions.test.ts\`, \`messaging.test.ts\`) were rebased on top of the test-utils refactor (#148) but the new pagination cursor tests from #54 still used the old \`server.tools.get(name)!()\` pattern, which broke when \`tools.get\` started returning \`{ schema, handler }\` instead of a bare callable. Switched those tests to \`server.callTool()\`.

Separately, \`profile.test.ts\` keeps an inline \`makeMockServer\` (it also exercises raw schemas), but didn't apply Zod \`.default()\` values when invoking handlers — so \`ig_business_discovery\` tests built URLs with \`{undefined}\`. Wrapped the registered handler so calling it parses args through the schema first, mirroring what test-utils and the real MCP SDK do at request time.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` — 384/384 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)