### PR TITLE
fix(deps): override ip-address to patch XSS (GHSA-v2v4-37r5-5v8g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Patched transitive `ip-address` XSS ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) / CVE-2026-42338, moderate)** — added an `overrides` entry pinning `ip-address` to `^10.1.1` so the transitive resolution under `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.2` (which still pins the vulnerable `10.1.0`, as does the latest `express-rate-limit@8.5.0`) is replaced with the patched `10.2.0`; the advisory only affects consumers that pass untrusted input through `Address6.group()`/`link()`/`spanAll()` or render `AddressError.parseMessage` as HTML, none of which meta-mcp does — but the override clears the Dependabot alert and protects downstream consumers that vendor the lockfile ([Dependabot #21](https://github.com/exileum/meta-mcp/security/dependabot/21))
+
 ## [5.0.0] — 2026-05-06
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1727,9 +1727,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.4.3"
   },
+  "overrides": {
+    "ip-address": "^10.1.1"
+  },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #21](https://github.com/exileum/meta-mcp/security/dependabot/21) — `ip-address` XSS in `Address6` HTML-emitting methods ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g), CVE-2026-42338, moderate, CVSS 4.0 = 5.3).
- Adds an `overrides` entry pinning `ip-address` to `^10.1.1`, which resolves to the patched `10.2.0` and clears the alert without any direct dependency or version bump.

## Context
The vulnerable resolution chain is `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.2 → ip-address@10.1.0`. The latest `express-rate-limit@8.5.0` still pins `ip-address@10.1.0`, so we cannot wait for an upstream patch — `npm audit fix --force` would downgrade the SDK to `1.25.3` (a breaking change). An `overrides` entry is the surgical fix.

The advisory only affects consumers that pass untrusted input through `Address6.group()` / `link()` / `spanAll()` or render `AddressError.parseMessage` as HTML. `grep -r 'ip-address\|Address6\|Address4' src/` confirms meta-mcp does not touch any of these surfaces — but the override clears the Dependabot signal and protects downstream consumers that vendor our lockfile.

## Changes
- `package.json` — added `overrides: { "ip-address": "^10.1.1" }`.
- `package-lock.json` — `ip-address` regenerated to `10.2.0` (semver-compatible patch within the same major).
- `CHANGELOG.md` — Security entry added under `[Unreleased]`.

## Test plan
- [x] `npm install` — 0 vulnerabilities reported by `npm audit`.
- [x] `npm ls ip-address` — confirms `10.2.0 overridden` under the SDK.
- [x] `npm run build` — clean `tsc` build.
- [x] `npm test` — 18/18 files, 384/384 tests pass.
- [x] No version bump — `version-sync` CI job stays green (`package.json` version unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)