### PR TITLE
fix: reject simultaneous image_url + video_url on threads_reply (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - **Patched transitive `ip-address` XSS ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) / CVE-2026-42338, moderate)** — added an `overrides` entry pinning `ip-address` to `^10.1.1` so the transitive resolution under `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.2` (which still pins the vulnerable `10.1.0`, as does the latest `express-rate-limit@8.5.0`) is replaced with the patched `10.2.0`; the advisory only affects consumers that pass untrusted input through `Address6.group()`/`link()`/`spanAll()` or render `AddressError.parseMessage` as HTML, none of which meta-mcp does — but the override clears the Dependabot alert and protects downstream consumers that vendor the lockfile ([Dependabot #21](https://github.com/exileum/meta-mcp/security/dependabot/21))
 
+### Fixed
+- **`threads_reply` silently accepted both `image_url` and `video_url` on the same reply** — the handler would assign `mediaType = "VIDEO"` (overriding `"IMAGE"`) but still forward both URLs to `POST /{user-id}/threads`, sending Meta an undefined-behavior combination. Added a handler-level validation that fast-fails with a clear error when both are provided. Per the [Threads Posts docs](https://developers.facebook.com/docs/threads/posts), each `media_type` has exactly one required URL field (`image_url` for IMAGE, `video_url` for VIDEO) and the spec doesn't define behavior when both are sent. The tool description and the `image_url` / `video_url` `.describe()` strings now spell out the mutual-exclusion constraint. Same conservative pattern as the [#185](https://github.com/exileum/meta-mcp/issues/185) `threads_publish_text` attachment mutual-exclusion fix ([#59](https://github.com/exileum/meta-mcp/issues/59))
+
 ## [5.0.0] — 2026-05-06
 
 ### Added

--- a/src/tools/threads/replies.test.ts
+++ b/src/tools/threads/replies.test.ts
@@ -248,3 +248,23 @@ describe("threads_reply auto_publish", () => {
     expect(calls[2][1]).toBe("/threads-123/threads_publish");
   });
 });
+
+describe("threads_reply image_url/video_url mutual exclusion", () => {
+  it("rejects providing both image_url and video_url", async () => {
+    const server = makeMockServer();
+    const client = makePublishMockClient();
+    registerThreadsReplyTools(server as never, client);
+
+    const handler = server.tools.get("threads_reply")!;
+    const result = await handler({
+      reply_to_id: "post-42",
+      text: "With both",
+      image_url: "https://example.com/photo.jpg",
+      video_url: "https://example.com/clip.mp4",
+    }) as { content: Array<{ text: string }>; isError: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("image_url and video_url cannot be combined on a single reply");
+    expect(client.threads).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/threads/replies.ts
+++ b/src/tools/threads/replies.ts
@@ -3,7 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { MetaClient } from "../../services/meta-client.js";
 import { httpsUrl } from "../../schemas.js";
 import { waitForThreadsContainer } from "../../utils/container.js";
-import { formatErrorResponse } from "../../utils/errors.js";
+import { formatErrorResponse, validationError } from "../../utils/errors.js";
 
 const REPLIES_BASE_FIELDS = "id,text,username,permalink,timestamp,media_type,media_url,has_replies,hide_status,root_post,replied_to,is_reply,is_quote_post";
 
@@ -50,16 +50,19 @@ export function registerThreadsReplyTools(server: McpServer, client: MetaClient)
   // ─── threads_reply ───────────────────────────────────────────
   server.tool(
     "threads_reply",
-    "Reply to a Threads post or another reply. Text-only replies publish in a single API call by default (auto_publish_text=true); media replies always use the two-step create-then-publish flow.",
+    "Reply to a Threads post or another reply. Text-only replies publish in a single API call by default (auto_publish_text=true); media replies always use the two-step create-then-publish flow. image_url and video_url are mutually exclusive — provide at most one.",
     {
       reply_to_id: z.string().describe("Post ID to reply to"),
       text: z.string().max(500).describe("Reply text"),
-      image_url: httpsUrl.optional().describe("Optional image HTTPS URL to attach"),
-      video_url: httpsUrl.optional().describe("Optional video HTTPS URL to attach"),
+      image_url: httpsUrl.optional().describe("Optional image HTTPS URL to attach. Mutually exclusive with video_url."),
+      video_url: httpsUrl.optional().describe("Optional video HTTPS URL to attach. Mutually exclusive with image_url."),
       auto_publish: z.boolean().optional().default(true).describe("When true (default) and the reply is text-only (no image_url/video_url), combine container creation and publishing into a single API call via auto_publish_text=true — one HTTP request instead of two, and no risk of the 4279009 'container not propagated yet' race. Ignored for media replies. Set to false to force the legacy two-step flow for text replies."),
     },
     async ({ reply_to_id, text, image_url, video_url, auto_publish }) => {
       try {
+        if (image_url && video_url) {
+          return validationError("image_url and video_url cannot be combined on a single reply");
+        }
         let mediaType = "TEXT";
         if (image_url) mediaType = "IMAGE";
         if (video_url) mediaType = "VIDEO";


### PR DESCRIPTION
## Summary
- `threads_reply` accepted both `image_url` and `video_url` simultaneously with no mutual-exclusivity check, forwarding an undefined-behavior combination to Meta.
- Added a handler-level validation that fast-fails with a clear error when both are provided, mirroring the [#185](https://github.com/exileum/meta-mcp/issues/185) `threads_publish_text` mutual-exclusion pattern.
- Per the [Threads Posts docs](https://developers.facebook.com/docs/threads/posts), each `media_type` requires exactly one URL field; behavior when both are sent is unspecified.

Fixes #59

## What was broken

`src/tools/threads/replies.ts` declared both `image_url` and `video_url` as `httpsUrl.optional()` with no validation. If a caller passed both:

```typescript
let mediaType = "TEXT";
if (image_url) mediaType = "IMAGE";
if (video_url) mediaType = "VIDEO";  // silently overrides IMAGE
// later:
if (image_url) params.image_url = image_url;  // both still added
if (video_url) params.video_url = video_url;
```

`mediaType` ended up `VIDEO` while **both** `image_url` and `video_url` were forwarded to `POST /{user-id}/threads`. The Threads API docs don't define behavior for this combination, so the result was unpredictable.

## What this PR does

- **`src/tools/threads/replies.ts`**:
  - Imports `validationError` alongside the existing `formatErrorResponse`.
  - Adds a handler-level guard at the top of the `threads_reply` handler:
    ```typescript
    if (image_url && video_url) {
      return validationError("image_url and video_url cannot be combined on a single reply");
    }
    ```
  - Updates the tool description to mention the constraint.
  - Updates `image_url` and `video_url` `.describe()` strings: `"Mutually exclusive with video_url."` / `"Mutually exclusive with image_url."`.
- **`src/tools/threads/replies.test.ts`**: adds a new `describe("threads_reply image_url/video_url mutual exclusion")` block with a test asserting the rejection returns `isError: true`, the structured-validation message, and that no API call was made. Image-only and video-only success paths are already covered by the existing tests at lines 206-249.
- **`CHANGELOG.md`**: new `### Fixed` subsection under `[Unreleased]` (the section previously contained only `### Security`) describing the fix.

## Why handler-level validation, not Zod refinement

The MCP SDK's `server.tool(name, desc, schema, handler)` signature takes a `ZodRawShape` (record of `ZodType`), not a `z.object(...)` instance, so `.refine()` / discriminated unions can't be hung off the schema without changing the SDK API surface. Every existing mutual-exclusion check in this codebase (PR [#185](https://github.com/exileum/meta-mcp/issues/185) in `publishing.ts:64-102`) uses handler-level validation via `validationError()` for exactly this reason. This PR keeps that consistency.

## Breaking changes
None. Callers that previously passed both `image_url` and `video_url` got undefined behavior from Meta; they now get a clear `validationError` instead. This is a strict behavior improvement — no existing valid call pattern is affected.

## Files changed
- `src/tools/threads/replies.ts` — `+7 / -4`
- `src/tools/threads/replies.test.ts` — `+20`
- `CHANGELOG.md` — `+3`

## Test plan
- [x] `npm run build` — passes (no type errors)
- [x] `npm test` — all 385 tests pass, including the new `threads_reply image_url/video_url mutual exclusion` test
- [x] `git diff` review — no drive-by changes; only the three files above are modified
- [ ] Live MCP end-to-end test — **not performed** at the user's request. The fix is exercised by the new unit test which asserts the structured-error response shape and verifies `client.threads` is not called when both URLs are passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)