### PR TITLE
fix: actually reject alt_text on threads_publish_text at schema level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`threads_publish_text` `alt_text` is now actually rejected at the schema level** — the v5.0.0 entry for [#185](https://github.com/exileum/meta-mcp/issues/185) claimed callers passing `alt_text` to `threads_publish_text` would now get a Zod schema error, but in practice the field was just omitted from the registered raw shape and `z.object()` defaults to `.strip()` — so the parameter was silently dropped and the post was published without it (live verification confirmed the post was created successfully when `alt_text` was passed). Restored the field as `z.never("…").optional()` so undefined still passes through but any defined value triggers a descriptive Zod issue pointing the caller at `threads_publish_image` / `threads_publish_video` / `threads_publish_carousel` instead. The handler-level mutual-exclusion checks added in [#185](https://github.com/exileum/meta-mcp/issues/185) are unchanged
+
 ### Security
 - **Patched transitive `ip-address` XSS ([GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) / CVE-2026-42338, moderate)** — added an `overrides` entry pinning `ip-address` to `^10.1.1` so the transitive resolution under `@modelcontextprotocol/sdk@1.29.0 → express-rate-limit@8.3.2` (which still pins the vulnerable `10.1.0`, as does the latest `express-rate-limit@8.5.0`) is replaced with the patched `10.2.0`; the advisory only affects consumers that pass untrusted input through `Address6.group()`/`link()`/`spanAll()` or render `AddressError.parseMessage` as HTML, none of which meta-mcp does — but the override clears the Dependabot alert and protects downstream consumers that vendor the lockfile ([Dependabot #21](https://github.com/exileum/meta-mcp/security/dependabot/21))
 

--- a/src/tools/threads/publishing.test.ts
+++ b/src/tools/threads/publishing.test.ts
@@ -899,6 +899,48 @@ describe("threads_publish_text attachment mutual exclusion", () => {
   });
 });
 
+// ─── alt_text rejection at the Zod schema level (#185 follow-up) ───
+//
+// v5.0.0 (#185) removed alt_text from the threads_publish_text schema and
+// claimed callers would now get a Zod schema error. The raw shape registered
+// without it was fine, but z.object() defaults to .strip() — so unknown keys
+// were silently dropped instead of throwing. This block locks in the explicit
+// rejection: alt_text declared as z.never("…").optional() so omitting passes
+// while passing any value triggers a descriptive Zod issue.
+
+describe("threads_publish_text alt_text rejection at the schema level", () => {
+  let server: ReturnType<typeof makeMockServer>;
+
+  beforeEach(() => {
+    server = makeMockServer();
+    registerThreadsPublishingTools(server as never, makeParamMockClient());
+  });
+
+  function getTextSchema(): z.ZodObject<z.ZodRawShape> {
+    const call = (server.tool as ReturnType<typeof vi.fn>).mock.calls.find(c => c[0] === "threads_publish_text");
+    if (!call) throw new Error("threads_publish_text was not registered");
+    return z.object(call[2] as z.ZodRawShape);
+  }
+
+  it("rejects alt_text with a descriptive message that points to the right tools", () => {
+    const result = getTextSchema().safeParse({ text: "Hello", alt_text: "image description" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["alt_text"]);
+      expect(result.error.issues[0].message).toContain("alt_text is not supported on text-only Threads posts");
+      expect(result.error.issues[0].message).toContain("threads_publish_image");
+    }
+  });
+
+  it("accepts the call when alt_text is omitted", () => {
+    expect(getTextSchema().safeParse({ text: "Hello" }).success).toBe(true);
+  });
+
+  it("accepts the call when alt_text is explicitly undefined", () => {
+    expect(getTextSchema().safeParse({ text: "Hello", alt_text: undefined }).success).toBe(true);
+  });
+});
+
 // ─── text_attachment char→byte offset conversion ────────────────────
 
 describe("threads_publish_text text_attachment byte offset conversion", () => {

--- a/src/tools/threads/publishing.ts
+++ b/src/tools/threads/publishing.ts
@@ -59,6 +59,7 @@ export function registerThreadsPublishingTools(server: McpServer, client: MetaCl
       text_attachment_link: z.string().url().optional().describe("URL to include inside the text attachment card. Requires text_attachment."),
       text_attachment_styling: textAttachmentStylingSchema,
       auto_publish: z.boolean().optional().default(true).describe("When true (default), combine container creation and publishing into a single API call via auto_publish_text=true — one HTTP request instead of two, and no risk of the 4279009 'container not propagated yet' race. Set to false to fall back to the legacy two-step flow (POST /threads, then POST /threads_publish)."),
+      alt_text: z.never("alt_text is not supported on text-only Threads posts (media_type=TEXT). Use threads_publish_image, threads_publish_video, or threads_publish_carousel for accessibility labels — those tools accept alt_text on IMAGE/VIDEO/CAROUSEL containers.").optional().describe("Reserved — must be omitted. alt_text is only supported on image, video, and carousel posts; passing it here raises a Zod schema error."),
     },
     async ({ text, reply_control, link_attachment, topic_tag, quote_post_id, poll_options, gif_id, gif_provider, is_spoiler, share_to_ig_story, allowlisted_country_codes, text_attachment, text_attachment_link, text_attachment_styling, auto_publish }) => {
       try {


### PR DESCRIPTION
## Summary

The v5.0.0 entry for [#185](https://github.com/exileum/meta-mcp/issues/185) claimed:

> Callers passing `alt_text` to `threads_publish_text` will now get a Zod schema error instead of having the parameter silently dropped.

Live verification on `@shiba.tenko` (Threads) showed this is **not** the actual behavior:

- `threads_publish_text({ text: "...", alt_text: "..." })` → returns `{ "id": "18105352807940973" }` and a real post is published, with `alt_text` silently dropped.

Root cause: `#185` removed `alt_text` from the registered raw shape, but the SDK builds `z.object(rawShape)` and Zod defaults to `.strip()` — unknown keys are discarded without throwing. The promised schema error never fires.

This PR restores the field as `z.never("…").optional()` so:

- omitting `alt_text` → identical behavior to today (Zod treats it as optional + undefined)
- passing any defined value → Zod issue at path `["alt_text"]` with a descriptive message that steers the caller to `threads_publish_image` / `threads_publish_video` / `threads_publish_carousel`

The handler-level mutual-exclusion checks added in #185 are untouched.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 7219 passed (3 new tests under `threads_publish_text alt_text rejection at the schema level`)
- [x] New tests cover: rejection with descriptive message, acceptance when omitted, acceptance when explicitly `undefined`
- [ ] Reviewer manual sanity check: pass `alt_text` to `threads_publish_text` via an MCP client and confirm a Zod validation error is returned instead of a successful post

🤖 Generated with [Claude Code](https://claude.com/claude-code)