### PR TITLE
refactor: consolidate sandbox and main registration via registerAll() (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Consolidated tool/resource/prompt registration into a single `registerAll()` helper** — `src/index.ts` previously listed the same 17 registration calls (14 tool registrars, 2 resource registrars, 1 prompt registrar) twice: once for the production stdio server and once inside `createSandboxServer()` for the Smithery sandbox. Adding a new tool module required editing both blocks, and forgetting to update the sandbox copy caused silent divergence — the Smithery sandbox would omit the new tool until somebody noticed. Extracted the sequence into a new module `src/register-all.ts` exporting `registerAll(server, client)`; both `src/index.ts` and `createSandboxServer()` now delegate to it. Registration order is preserved exactly, so the registered tool/resource/prompt sequence is byte-identical to before. Added `src/register-all.test.ts`, a snapshot test that asserts every expected tool name, resource URI, and prompt name in registration order — a future tool module wired up to only one of the two paths is now impossible because there is only one path. No public-API or behavior change: `createSandboxServer()` keeps the same signature and return type ([#47](https://github.com/exileum/meta-mcp/issues/47))
+
 ## [6.0.0] — 2026-05-07
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,31 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadConfig, MetaConfig } from "./config.js";
 import { MetaClient } from "./services/meta-client.js";
-
-// Meta platform tools
-import { registerMetaAuthTools } from "./tools/meta/auth.js";
-
-// Instagram tools
-import { registerIgPublishingTools } from "./tools/instagram/publishing.js";
-import { registerIgMediaTools } from "./tools/instagram/media.js";
-import { registerIgCommentTools } from "./tools/instagram/comments.js";
-import { registerIgProfileTools } from "./tools/instagram/profile.js";
-import { registerIgHashtagTools } from "./tools/instagram/hashtags.js";
-import { registerIgMentionTools } from "./tools/instagram/mentions.js";
-import { registerIgMessagingTools } from "./tools/instagram/messaging.js";
-
-// Threads tools
-import { registerThreadsPublishingTools } from "./tools/threads/publishing.js";
-import { registerThreadsMediaTools } from "./tools/threads/media.js";
-import { registerThreadsReplyTools } from "./tools/threads/replies.js";
-import { registerThreadsProfileTools } from "./tools/threads/profile.js";
-import { registerThreadsInsightTools } from "./tools/threads/insights.js";
-import { registerThreadsMentionsTools } from "./tools/threads/mentions.js";
-
-// Resources & Prompts
-import { registerInstagramResources } from "./resources/instagram.js";
-import { registerThreadsResources } from "./resources/threads.js";
-import { registerPrompts } from "./prompts/index.js";
+import { registerAll } from "./register-all.js";
 
 const require = createRequire(import.meta.url);
 const { version: SERVER_VERSION } = require("../package.json") as { version: string };
@@ -48,28 +24,7 @@ try {
 }
 const client = new MetaClient(config);
 
-// Register tools
-registerMetaAuthTools(server, client);
-registerIgPublishingTools(server, client);
-registerIgMediaTools(server, client);
-registerIgCommentTools(server, client);
-registerIgProfileTools(server, client);
-registerIgHashtagTools(server, client);
-registerIgMentionTools(server, client);
-registerIgMessagingTools(server, client);
-registerThreadsPublishingTools(server, client);
-registerThreadsMediaTools(server, client);
-registerThreadsReplyTools(server, client);
-registerThreadsProfileTools(server, client);
-registerThreadsInsightTools(server, client);
-registerThreadsMentionsTools(server, client);
-
-// Register resources
-registerInstagramResources(server, client);
-registerThreadsResources(server, client);
-
-// Register prompts
-registerPrompts(server);
+registerAll(server, client);
 
 async function main() {
   const transport = new StdioServerTransport();
@@ -99,23 +54,7 @@ export function createSandboxServer() {
   };
   const mockClient = new MetaClient(mockConfig);
 
-  registerMetaAuthTools(sandbox, mockClient);
-  registerIgPublishingTools(sandbox, mockClient);
-  registerIgMediaTools(sandbox, mockClient);
-  registerIgCommentTools(sandbox, mockClient);
-  registerIgProfileTools(sandbox, mockClient);
-  registerIgHashtagTools(sandbox, mockClient);
-  registerIgMentionTools(sandbox, mockClient);
-  registerIgMessagingTools(sandbox, mockClient);
-  registerThreadsPublishingTools(sandbox, mockClient);
-  registerThreadsMediaTools(sandbox, mockClient);
-  registerThreadsReplyTools(sandbox, mockClient);
-  registerThreadsProfileTools(sandbox, mockClient);
-  registerThreadsInsightTools(sandbox, mockClient);
-  registerThreadsMentionsTools(sandbox, mockClient);
-  registerInstagramResources(sandbox, mockClient);
-  registerThreadsResources(sandbox, mockClient);
-  registerPrompts(sandbox);
+  registerAll(sandbox, mockClient);
 
   return sandbox;
 }

--- a/src/register-all.test.ts
+++ b/src/register-all.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerAll } from "./register-all.js";
+import type { MetaClient } from "./services/meta-client.js";
+
+type RegistrationLog = {
+  tools: string[];
+  resources: { name: string; uri: string }[];
+  prompts: string[];
+};
+
+function makeMockServer(): RegistrationLog & {
+  tool: ReturnType<typeof vi.fn>;
+  resource: ReturnType<typeof vi.fn>;
+  prompt: ReturnType<typeof vi.fn>;
+} {
+  const log: RegistrationLog = { tools: [], resources: [], prompts: [] };
+  return {
+    ...log,
+    tool: vi.fn((name: string) => {
+      log.tools.push(name);
+    }),
+    resource: vi.fn((name: string, uri: string) => {
+      log.resources.push({ name, uri });
+    }),
+    prompt: vi.fn((name: string) => {
+      log.prompts.push(name);
+    }),
+  };
+}
+
+describe("registerAll", () => {
+  it("registers every tool, resource, and prompt in the expected order", () => {
+    const server = makeMockServer();
+    const client = {} as unknown as MetaClient;
+
+    registerAll(server as never, client);
+
+    expect(server.tools).toEqual([
+      "meta_exchange_token",
+      "meta_refresh_token",
+      "meta_debug_token",
+      "meta_get_app_info",
+      "meta_subscribe_webhook",
+      "meta_get_webhook_subscriptions",
+      "ig_publish_photo",
+      "ig_publish_video",
+      "ig_publish_carousel",
+      "ig_publish_reel",
+      "ig_publish_story",
+      "ig_get_container_status",
+      "ig_get_media_list",
+      "ig_get_media",
+      "ig_delete_media",
+      "ig_get_media_insights",
+      "ig_toggle_comments",
+      "ig_get_comments",
+      "ig_get_comment",
+      "ig_post_comment",
+      "ig_get_replies",
+      "ig_reply_to_comment",
+      "ig_hide_comment",
+      "ig_delete_comment",
+      "ig_get_profile",
+      "ig_get_account_insights",
+      "ig_business_discovery",
+      "ig_get_collaboration_invites",
+      "ig_respond_collaboration_invite",
+      "ig_search_hashtag",
+      "ig_get_hashtag",
+      "ig_get_hashtag_recent",
+      "ig_get_hashtag_top",
+      "ig_get_mentioned_comment",
+      "ig_get_tagged_media",
+      "ig_get_conversations",
+      "ig_get_messages",
+      "ig_send_message",
+      "ig_get_message",
+      "threads_publish_text",
+      "threads_publish_image",
+      "threads_publish_video",
+      "threads_publish_carousel",
+      "threads_delete_post",
+      "threads_get_container_status",
+      "threads_get_publishing_limit",
+      "threads_repost",
+      "threads_get_posts",
+      "threads_get_post",
+      "threads_search_posts",
+      "threads_get_replies",
+      "threads_reply",
+      "threads_hide_reply",
+      "threads_unhide_reply",
+      "threads_get_profile",
+      "threads_get_post_insights",
+      "threads_get_user_insights",
+      "threads_get_mentions",
+    ]);
+
+    expect(server.resources).toEqual([
+      { name: "instagram-profile", uri: "meta-mcp://instagram/profile" },
+      { name: "threads-profile", uri: "meta-mcp://threads/profile" },
+    ]);
+
+    expect(server.prompts).toEqual(["content_publish", "analytics_report"]);
+  });
+});

--- a/src/register-all.test.ts
+++ b/src/register-all.test.ts
@@ -1,30 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerAll } from "./register-all.js";
 import type { MetaClient } from "./services/meta-client.js";
 
-type RegistrationLog = {
-  tools: string[];
-  resources: { name: string; uri: string }[];
-  prompts: string[];
-};
-
-function makeMockServer(): RegistrationLog & {
-  tool: ReturnType<typeof vi.fn>;
-  resource: ReturnType<typeof vi.fn>;
-  prompt: ReturnType<typeof vi.fn>;
-} {
-  const log: RegistrationLog = { tools: [], resources: [], prompts: [] };
+function makeMockServer() {
+  const tools: string[] = [];
+  const resources: { name: string; uri: string }[] = [];
+  const prompts: string[] = [];
   return {
-    ...log,
-    tool: vi.fn((name: string) => {
-      log.tools.push(name);
-    }),
-    resource: vi.fn((name: string, uri: string) => {
-      log.resources.push({ name, uri });
-    }),
-    prompt: vi.fn((name: string) => {
-      log.prompts.push(name);
-    }),
+    tools,
+    resources,
+    prompts,
+    tool: vi.fn((name: string) => tools.push(name)),
+    resource: vi.fn((name: string, uri: string) => resources.push({ name, uri })),
+    prompt: vi.fn((name: string) => prompts.push(name)),
   };
 }
 
@@ -33,7 +22,7 @@ describe("registerAll", () => {
     const server = makeMockServer();
     const client = {} as unknown as MetaClient;
 
-    registerAll(server as never, client);
+    registerAll(server as unknown as McpServer, client);
 
     expect(server.tools).toEqual([
       "meta_exchange_token",

--- a/src/register-all.ts
+++ b/src/register-all.ts
@@ -1,0 +1,47 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { MetaClient } from "./services/meta-client.js";
+
+// Meta platform tools
+import { registerMetaAuthTools } from "./tools/meta/auth.js";
+
+// Instagram tools
+import { registerIgPublishingTools } from "./tools/instagram/publishing.js";
+import { registerIgMediaTools } from "./tools/instagram/media.js";
+import { registerIgCommentTools } from "./tools/instagram/comments.js";
+import { registerIgProfileTools } from "./tools/instagram/profile.js";
+import { registerIgHashtagTools } from "./tools/instagram/hashtags.js";
+import { registerIgMentionTools } from "./tools/instagram/mentions.js";
+import { registerIgMessagingTools } from "./tools/instagram/messaging.js";
+
+// Threads tools
+import { registerThreadsPublishingTools } from "./tools/threads/publishing.js";
+import { registerThreadsMediaTools } from "./tools/threads/media.js";
+import { registerThreadsReplyTools } from "./tools/threads/replies.js";
+import { registerThreadsProfileTools } from "./tools/threads/profile.js";
+import { registerThreadsInsightTools } from "./tools/threads/insights.js";
+import { registerThreadsMentionsTools } from "./tools/threads/mentions.js";
+
+// Resources & Prompts
+import { registerInstagramResources } from "./resources/instagram.js";
+import { registerThreadsResources } from "./resources/threads.js";
+import { registerPrompts } from "./prompts/index.js";
+
+export function registerAll(server: McpServer, client: MetaClient): void {
+  registerMetaAuthTools(server, client);
+  registerIgPublishingTools(server, client);
+  registerIgMediaTools(server, client);
+  registerIgCommentTools(server, client);
+  registerIgProfileTools(server, client);
+  registerIgHashtagTools(server, client);
+  registerIgMentionTools(server, client);
+  registerIgMessagingTools(server, client);
+  registerThreadsPublishingTools(server, client);
+  registerThreadsMediaTools(server, client);
+  registerThreadsReplyTools(server, client);
+  registerThreadsProfileTools(server, client);
+  registerThreadsInsightTools(server, client);
+  registerThreadsMentionsTools(server, client);
+  registerInstagramResources(server, client);
+  registerThreadsResources(server, client);
+  registerPrompts(server);
+}


### PR DESCRIPTION
## Summary

- Extract the 17 tool/resource/prompt registration calls into a single `registerAll()` helper in a new `src/register-all.ts`
- Both the top-level production server and `createSandboxServer()` now delegate to it — eliminating the silent-divergence footgun where adding a tool to one path but not the other would ship a broken Smithery sandbox
- Add a snapshot test in `src/register-all.test.ts` that asserts every expected tool name, resource URI, and prompt name in registration order

Fixes #47

## What was broken

`src/index.ts` listed the same 17 registration calls (14 tool registrars + 2 resource registrars + 1 prompt registrar) twice:

- Lines 52–72 — the top-level production stdio server
- Lines 102–118 — inside `createSandboxServer()` for the Smithery sandbox

Adding a new tool module required updating **both** lists. Forgetting to update the sandbox caused silent divergence: the Smithery preview would omit the new tool until somebody noticed. The issue itself was filed when the issue author counted 15 duplicated calls; that count had drifted to 17 by the time of this fix, which is exactly the kind of churn the original report warned about.

## What this PR does

1. **`src/register-all.ts` (new)** — exports `registerAll(server, client)` which calls every registrar in the same order the previous inline blocks did. Registration order is preserved byte-for-byte.
2. **`src/index.ts`** — drops 17 inline calls in two places (and the matching imports), now just calls `registerAll(...)` twice. Net diff: -64 / +6 lines.
3. **`src/register-all.test.ts` (new)** — snapshot test using a mocked `McpServer` that records every `tool` / `resource` / `prompt` call. Asserts every expected name in the documented order, so a future regression (a tool module wired up but missing from `registerAll`) fails CI with a clear list-diff message.
4. **`CHANGELOG.md`** — entry under `[Unreleased]` › `### Changed`.

Why a separate module rather than a private function in `src/index.ts` (which is what the issue's snippet sketched): a test importing `src/index.ts` would trigger `loadConfig()` and `main()` as module side effects (this was explicitly noted in the [6.0.0] CHANGELOG entry). A dedicated module lets the test exercise `registerAll` directly without environment setup or stdio-transport mocking.

## Breaking changes

None. `createSandboxServer()` keeps the same signature and return type. No public API or tool surface changed. Same 17 registrations, same order, on both code paths.

## Files changed

- `src/register-all.ts` (new) — 47 lines, single exported `registerAll()` function
- `src/index.ts` — -64 / +6 lines
- `src/register-all.test.ts` (new) — snapshot covering 58 tools, 2 resources, 2 prompts
- `CHANGELOG.md` — `[Unreleased]` entry

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 471/471 passing, including the new `registerAll` snapshot
- [x] `npm run lint` — clean
- [x] Confirmed `dist/` ships `register-all.js` and `register-all.d.ts`, with no `*.test.*` artifacts (tsconfig already excludes test files)
- [x] `git diff src/index.ts` — both registration blocks reduced to a single `registerAll(...)` call; mockConfig shape and `createSandboxServer()` signature unchanged
- [ ] Live MCP test — **not performed**. The diff doesn't touch any tool handler code (endpoints, parameters, request/response logic) — purely changes registration wiring. Behavior is byte-identical and covered by the snapshot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)