### PR TITLE
chore: add prepublishOnly script to guard local npm publish (#68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

Adds `"prepublishOnly": "npm run build"` to `package.json` `scripts` so `tsc` runs automatically before any `npm publish`, closing the gap where a maintainer publishing from their local machine could ship a stale or missing `dist/`.

Fixes #68

## What was broken

`package.json` had no `prepublishOnly` / `prepare` / `prepack` lifecycle script. The release workflow (`.github/workflows/release.yml:54`) already runs `npm ci && npm run build` before `npm publish` and is safe, but **local** `npm publish` had no equivalent safety net:

- **Stale `dist/`** — developer changes `src/`, forgets to rebuild, runs `npm publish` → old `dist/` ships.
- **Missing `dist/`** — fresh clone, `npm install`, `npm publish` (no `npm run build`) → empty/missing `dist/` ships.

## What this PR does

Adds the canonical npm lifecycle hook documented at https://docs.npmjs.com/cli/v10/using-npm/scripts. Per the npm docs, `prepublishOnly` runs **only** on `npm publish` (never on `npm install`, never on `npm pack`), so:

- The release workflow now harmlessly re-runs `tsc` between `npm run build` and `npm publish` (no-op since `dist/` is already fresh).
- Local `npm publish` now always rebuilds first.
- Consumers running `npm install @exileum/meta-mcp` are unaffected — the hook never fires for them.

### Why only `npm run build` (not also `npm test`)

Following the issue's literal recommendation. The release workflow itself only does `npm ci && npm run build` before publish — no tests. Adding tests to `prepublishOnly` would be **stricter** than the canonical release path, which is inconsistent. Tests already gate every PR via `.github/workflows/ci.yml` before merge to `main`.

## Breaking changes

None. The hook fires only on `npm publish`, never during `npm install` for consumers; the npm tarball contents are unchanged.

## Files changed

- `package.json` — one line added in `scripts`.

## Why no CHANGELOG entry

Per [`CONTRIBUTING.md`](https://github.com/exileum/meta-mcp/blob/main/CONTRIBUTING.md#L124) — "Changes that touch only repo-level governance … are **not** logged in `CHANGELOG.md`." `prepublishOnly` is a publisher-side hook that consumers never execute on `npm install`; this is the same governance category as `.github/` workflow changes. The commit message and this PR description are the canonical record.

## Test plan

- [x] `npm run build` — passes cleanly.
- [x] `npm test` — all 628 tests in 22 files pass.
- [x] `npm publish --dry-run` — confirmed the hook fires; output starts with `> @exileum/meta-mcp@7.0.0 prepublishOnly` followed by `> npm run build` and `> tsc`, then the would-publish tarball listing.
- [x] `dist/` contains no test artifacts (`*.test.*`, `test-utils*`).
- [x] No live MCP testing needed — no MCP tool handler code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)